### PR TITLE
geom_alt props

### DIFF
--- a/data/101/749/137/101749137.geojson
+++ b/data/101/749/137/101749137.geojson
@@ -368,6 +368,9 @@
         "wk:page":"Famagusta"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"759471e7fd524d07afe1fc666c63036e",
     "wof:hierarchy":[
         {
@@ -403,7 +406,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709999,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u0391\u03bc\u03bc\u03cc\u03c7\u03c9\u03c3\u03c4\u03bf\u03c2",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/749/139/101749139.geojson
+++ b/data/101/749/139/101749139.geojson
@@ -301,6 +301,9 @@
         "wk:page":"Kyrenia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4caf659bc2a5183a4830d8c66901e935",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709999,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039a\u03b5\u03c1\u03cd\u03bd\u03b5\u03b9\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/749/141/101749141.geojson
+++ b/data/101/749/141/101749141.geojson
@@ -689,6 +689,9 @@
         "wk:page":"Nicosia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8d868c7caab45c12aba2bee156080428",
     "wof:hierarchy":[
         {
@@ -716,7 +719,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709999,
+    "wof:lastmodified":1582314070,
     "wof:megacity":0,
     "wof:name":"\u039b\u03b5\u03c5\u03ba\u03c9\u03c3\u03af\u03b1",
     "wof:parent_id":-4,

--- a/data/101/749/143/101749143.geojson
+++ b/data/101/749/143/101749143.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Paphos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0bc3eca648b2c88dd84b897d3b27095f",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709999,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u03a0\u03ac\u03c6\u03bf\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/749/145/101749145.geojson
+++ b/data/101/749/145/101749145.geojson
@@ -374,6 +374,9 @@
         "wk:page":"Larnaca"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0708a2ef188fd6f5a4bc40e9afb7528a",
     "wof:hierarchy":[
         {
@@ -387,7 +390,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709998,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039b\u03ac\u03c1\u03bd\u03b1\u03ba\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/749/147/101749147.geojson
+++ b/data/101/749/147/101749147.geojson
@@ -379,6 +379,9 @@
         "wk:page":"Limassol"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b547eeef146a89fc23e76c2669d0da2a",
     "wof:hierarchy":[
         {
@@ -392,7 +395,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709999,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039b\u03b5\u03bc\u03b5\u03c3\u03cc\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/753/033/101753033.geojson
+++ b/data/101/753/033/101753033.geojson
@@ -142,6 +142,9 @@
         "woe:id":841711
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9f59ccb4ae3a7837a2fdc0d8cf387955",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709963,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u03a3\u03c4\u03c1\u03cc\u03b2\u03bf\u03bb\u03bf\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/753/065/101753065.geojson
+++ b/data/101/753/065/101753065.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Mesogi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae11f7bdc304c75f242704a19efee146",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709963,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039c\u03b5\u03c3\u03cc\u03b3\u03b7",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/756/141/101756141.geojson
+++ b/data/101/756/141/101756141.geojson
@@ -65,6 +65,9 @@
         "qs_pg:id":232875
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bedaef3e384a013641011d5f4b796944",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566710002,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u0393\u03b5\u03ce\u03c1\u03b3\u03b9\u03bf\u03c2",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/756/165/101756165.geojson
+++ b/data/101/756/165/101756165.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Konia, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f083557667fba5c6eafca08e9d877f8",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710001,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039a\u03bf\u03bd\u03b9\u03ac",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/756/171/101756171.geojson
+++ b/data/101/756/171/101756171.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Empa, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c9c689cb1a0885da69f58d55fb21697c",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101756171,
-    "wof:lastmodified":1566710003,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u0388\u03bc\u03c0\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/756/179/101756179.geojson
+++ b/data/101/756/179/101756179.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Livadia, Larnaca"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c9347caa5d74b793a8c8407616c05642",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710002,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039b\u03b9\u03b2\u03ac\u03b4\u03b9\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/756/181/101756181.geojson
+++ b/data/101/756/181/101756181.geojson
@@ -118,6 +118,9 @@
         "wd:id":"Q7103757"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"acf31f635d94ab09fabd58ea2a014934",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710001,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u0392\u03bf\u03c1\u03cc\u03ba\u03bb\u03b7\u03bd\u03b7",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/756/183/101756183.geojson
+++ b/data/101/756/183/101756183.geojson
@@ -155,6 +155,9 @@
         "wk:page":"Aradippou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bfe035fff677d46ca14b31f8340adaf3",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710002,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u0391\u03c1\u03b1\u03b4\u03af\u03c0\u03c0\u03bf\u03c5",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/756/189/101756189.geojson
+++ b/data/101/756/189/101756189.geojson
@@ -108,6 +108,9 @@
         "wd:id":"Q16269888"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5d4f17a4aaedea41cb6df6f892407bdc",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710001,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u03a0\u03ac\u03bd\u03c9 \u03a0\u03bf\u03bb\u03b5\u03bc\u03af\u03b4\u03b9\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/756/191/101756191.geojson
+++ b/data/101/756/191/101756191.geojson
@@ -121,6 +121,9 @@
         "wk:page":"Ypsonas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b092a5b10b820044234a6ee10f530f3b",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710001,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u038e\u03c8\u03c9\u03bd\u03b1\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/756/193/101756193.geojson
+++ b/data/101/756/193/101756193.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Mouttagiaka"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b1d3bcb018f9ce7359b71ae881eb9497",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710000,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039c\u03bf\u03c5\u03c4\u03c4\u03b1\u03b3\u03b9\u03ac\u03ba\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/756/199/101756199.geojson
+++ b/data/101/756/199/101756199.geojson
@@ -136,6 +136,9 @@
         "wd:id":"Q2423938"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd795329fa1ed42b0383bca80cccf68b",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710002,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039a\u03ac\u03c4\u03c9 \u03a0\u03bf\u03bb\u03b5\u03bc\u03af\u03b4\u03b9\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/758/483/101758483.geojson
+++ b/data/101/758/483/101758483.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Karmi, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"79ea058e4d7964da309b5fd44d013583",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709999,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039a\u03ac\u03c1\u03bc\u03b9",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/175/101803175.geojson
+++ b/data/101/803/175/101803175.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Liopetri"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de4d66d00222abf223a264dfedbce0d4",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709990,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039b\u03b9\u03bf\u03c0\u03ad\u03c4\u03c1\u03b9",
     "wof:parent_id":85682389,
     "wof:placetype":"locality",

--- a/data/101/803/177/101803177.geojson
+++ b/data/101/803/177/101803177.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Frenaros"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea106a0d10a621ed1a8a8a0259724c05",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709997,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u03a6\u03c1\u03ad\u03bd\u03b1\u03c1\u03bf\u03c2",
     "wof:parent_id":85682389,
     "wof:placetype":"locality",

--- a/data/101/803/179/101803179.geojson
+++ b/data/101/803/179/101803179.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Acheritou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d809887504cf2f90c7fb510f93b4e52e",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709997,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u0391\u03c7\u03b5\u03c1\u03af\u03c4\u03bf\u03c5",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/181/101803181.geojson
+++ b/data/101/803/181/101803181.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Avgorou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"be360005898a5011a3035a1f6fe5477b",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709990,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u0391\u03c5\u03b3\u03cc\u03c1\u03bf\u03c5",
     "wof:parent_id":85682389,
     "wof:placetype":"locality",

--- a/data/101/803/183/101803183.geojson
+++ b/data/101/803/183/101803183.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Makrasyka"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"45aa6731a66f59776f13dd6b270ad58c",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709997,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039c\u03b1\u03ba\u03c1\u03ac\u03c3\u03c5\u03ba\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/193/101803193.geojson
+++ b/data/101/803/193/101803193.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Spathariko"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a5a0cc9fed8d970f73830fae32794ee9",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709985,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u03a3\u03c0\u03b1\u03b8\u03b1\u03c1\u03b9\u03ba\u03cc",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/205/101803205.geojson
+++ b/data/101/803/205/101803205.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Trikomo, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"36666c8ede6b1989f3ca002b2dc0f131",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709989,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u03a4\u03c1\u03af\u03ba\u03c9\u03bc\u03bf",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/223/101803223.geojson
+++ b/data/101/803/223/101803223.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":42560
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eaebfaa8d50ba18ea843c13bf313fde0",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709994,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u03a0\u03c1\u03b1\u03c3\u03c4\u03b9\u03cc",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/235/101803235.geojson
+++ b/data/101/803/235/101803235.geojson
@@ -136,6 +136,9 @@
         "wk:page":"Lefkoniko"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f4282880b41bfff983ff272bfc303e09",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709988,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039b\u03b5\u03c5\u03ba\u03cc\u03bd\u03bf\u03b9\u03ba\u03bf",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/283/101803283.geojson
+++ b/data/101/803/283/101803283.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Gastria"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b3d5d93fda1f9a93483f0629e5da56c",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709993,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u0393\u03b1\u03c3\u03c4\u03c1\u03b9\u03ac",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/339/101803339.geojson
+++ b/data/101/803/339/101803339.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Rizokarpaso"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2bf8451ccdaec1950fe19335b7b2d0a1",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709985,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u03a1\u03b9\u03b6\u03bf\u03ba\u03ac\u03c1\u03c0\u03b1\u03c3\u03bf",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/371/101803371.geojson
+++ b/data/101/803/371/101803371.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Klepini"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"087ac0fcb3de89c352f7a5cc56bb709f",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566709990,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039a\u03bb\u03b5\u03c0\u03af\u03bd\u03b7",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/379/101803379.geojson
+++ b/data/101/803/379/101803379.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Karavostasi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3cb891695cc1a249ee5e72572776e5fb",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709989,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039a\u03b1\u03c1\u03b1\u03b2\u03bf\u03c3\u03c4\u03ac\u03c3\u03b9",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/389/101803389.geojson
+++ b/data/101/803/389/101803389.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Mathiatis"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4203a87900d66759484d02d72eb7fc46",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101803389,
-    "wof:lastmodified":1566709997,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039c\u03b1\u03b8\u03b9\u03ac\u03c4\u03b7\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/395/101803395.geojson
+++ b/data/101/803/395/101803395.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Lythrodontas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eef098ebc53ff27eaee4f0cf12e333bc",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709991,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039b\u03c5\u03b8\u03c1\u03bf\u03b4\u03cc\u03bd\u03c4\u03b1\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/397/101803397.geojson
+++ b/data/101/803/397/101803397.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Potamia, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c4109dad119ca48dec954317174be418",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709986,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u03a0\u03bf\u03c4\u03b1\u03bc\u03b9\u03ac",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/403/101803403.geojson
+++ b/data/101/803/403/101803403.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Gourri"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6cecbb34926766bdbc3ab02ab28fdf29",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709996,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u0393\u03bf\u03cd\u03c1\u03c1\u03b7",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/407/101803407.geojson
+++ b/data/101/803/407/101803407.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Arediou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b9f4ed18683da9e140591c1fb45b5bcd",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709988,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u0391\u03c1\u03b5\u03b4\u03b9\u03bf\u03cd",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/411/101803411.geojson
+++ b/data/101/803/411/101803411.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Agrokipia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf27b874176e3ee7022cb1267fa44d53",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709994,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u0391\u03b3\u03c1\u03bf\u03ba\u03b7\u03c0\u03b9\u03ac",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/413/101803413.geojson
+++ b/data/101/803/413/101803413.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Mitsero"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8092dbe11cf0182fe17d0fb0690e8b90",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709987,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039c\u03b9\u03c4\u03c3\u03b5\u03c1\u03cc",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/417/101803417.geojson
+++ b/data/101/803/417/101803417.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Analiontas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d56066d3d18bd9d905052edb72ac1839",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709993,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u0391\u03bd\u03b1\u03bb\u03b9\u03cc\u03bd\u03c4\u03b1\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/421/101803421.geojson
+++ b/data/101/803/421/101803421.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Kampia, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d58475c7f59a755001555399bac08afb",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709993,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039a\u03b1\u03bc\u03c0\u03b9\u03ac",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/423/101803423.geojson
+++ b/data/101/803/423/101803423.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Episkopeio"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"37a2dc7a48c1b1d1e8d50a87007b8981",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709987,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u0395\u03c0\u03b9\u03c3\u03ba\u03bf\u03c0\u03b5\u03b9\u03cc",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/425/101803425.geojson
+++ b/data/101/803/425/101803425.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Ergates"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8d35590148f052cad67954629105c3e2",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101803425,
-    "wof:lastmodified":1566709986,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u0395\u03c1\u03b3\u03ac\u03c4\u03b5\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/431/101803431.geojson
+++ b/data/101/803/431/101803431.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Deneia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ed0ce0720906f812f6a62023f64e1195",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709988,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u0394\u03ad\u03bd\u03b5\u03b9\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/433/101803433.geojson
+++ b/data/101/803/433/101803433.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Kokkinotrimithia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2548f21920b62ae52828234b213c2351",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709996,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039a\u03bf\u03ba\u03ba\u03b9\u03bd\u03bf\u03c4\u03c1\u03b9\u03bc\u03b9\u03b8\u03b9\u03ac",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/435/101803435.geojson
+++ b/data/101/803/435/101803435.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Mammari"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3b8c2598980d72bf2a5a7a33645c36b7",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709996,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039c\u03ac\u03bc\u03bc\u03b1\u03c1\u03b7",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/439/101803439.geojson
+++ b/data/101/803/439/101803439.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Alona, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4a08bb7d93de9837d92f66aa3f96c0b1",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709988,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u0386\u03bb\u03c9\u03bd\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/441/101803441.geojson
+++ b/data/101/803/441/101803441.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Xyliatos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea9eec95de797d8cd5a8f1f873e0e995",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709987,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039e\u03c5\u03bb\u03b9\u03b1\u03c4\u03cc\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/443/101803443.geojson
+++ b/data/101/803/443/101803443.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Nikitari"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9508dcc1c7e37050a0fa6fb99f87cca3",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709993,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039d\u03b9\u03ba\u03b7\u03c4\u03ac\u03c1\u03b9",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/445/101803445.geojson
+++ b/data/101/803/445/101803445.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Vyzakia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"286c36df09b4f53e9cf6d472f37ac61c",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709995,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u0392\u03c5\u03b6\u03b1\u03ba\u03b9\u03ac",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/449/101803449.geojson
+++ b/data/101/803/449/101803449.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Kato Moni"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"453301d1cbcb64bc30c4b4b1ee03ce7e",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101803449,
-    "wof:lastmodified":1566709986,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039a\u03ac\u03c4\u03c9 \u039c\u03bf\u03bd\u03ae",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/451/101803451.geojson
+++ b/data/101/803/451/101803451.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Orounta"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"93cb73c508c5a87b55eb2cfbc84b5683",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709995,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039f\u03c1\u03bf\u03cd\u03bd\u03c4\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/453/101803453.geojson
+++ b/data/101/803/453/101803453.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Potami"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea0acde57f8c4a96b6712fb20c2c9818",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709989,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u03a0\u03bf\u03c4\u03ac\u03bc\u03b9",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/457/101803457.geojson
+++ b/data/101/803/457/101803457.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Akaki, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8f61500f2f37c7abe56bf3cc254b9748",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709996,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u0391\u03ba\u03ac\u03ba\u03b9",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/459/101803459.geojson
+++ b/data/101/803/459/101803459.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Peristerona"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c627df68dc8c8f73e5ffc00853148cdf",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709996,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u03a0\u03b5\u03c1\u03b9\u03c3\u03c4\u03b5\u03c1\u03ce\u03bd\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/461/101803461.geojson
+++ b/data/101/803/461/101803461.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Astromeritis"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca1b21fc15e463ccf3656dd5a7e1e370",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709996,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u0391\u03c3\u03c4\u03c1\u03bf\u03bc\u03b5\u03c1\u03af\u03c4\u03b7\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/463/101803463.geojson
+++ b/data/101/803/463/101803463.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Meniko"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"66761e7f70d58cabb310028faf84b732",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101803463,
-    "wof:lastmodified":1566709988,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039c\u03ad\u03bd\u03b9\u03ba\u03bf",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/467/101803467.geojson
+++ b/data/101/803/467/101803467.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Korakou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76d4ac71c80c2f8a0365712117373e46",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709995,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039a\u03bf\u03c1\u03ac\u03ba\u03bf\u03c5",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/471/101803471.geojson
+++ b/data/101/803/471/101803471.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Gerakies"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"afcc885bf3ed3df7153607cf101e745c",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709986,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u0393\u03b5\u03c1\u03b1\u03ba\u03b9\u03ad\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/475/101803475.geojson
+++ b/data/101/803/475/101803475.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Kampos, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"13458296cefba101e83a69aa750faa6a",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709993,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039a\u03ac\u03bc\u03c0\u03bf\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/477/101803477.geojson
+++ b/data/101/803/477/101803477.geojson
@@ -96,6 +96,9 @@
         "wd:id":"Q4363305"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3cba9a161c2a99dde42221a941667d58",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709987,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u03a0\u03ac\u03bd\u03c9 \u03a0\u03cd\u03c1\u03b3\u03bf\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/479/101803479.geojson
+++ b/data/101/803/479/101803479.geojson
@@ -100,6 +100,9 @@
         "wd:id":"Q4363305"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"921ed16d8024924fded513524cde7017",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709987,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039a\u03ac\u03c4\u03c9 \u03a0\u03cd\u03c1\u03b3\u03bf\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/481/101803481.geojson
+++ b/data/101/803/481/101803481.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Tseri"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a45ce0e822c780f533470ff7c2c720a6",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709993,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u03a4\u03c3\u03ad\u03c1\u03b9",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/803/529/101803529.geojson
+++ b/data/101/803/529/101803529.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Lefka"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1c870b485e0368f05aeee6c20290b85b",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709990,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039b\u03b5\u03cd\u03ba\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/531/101803531.geojson
+++ b/data/101/803/531/101803531.geojson
@@ -164,6 +164,9 @@
         "wk:page":"Morphou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1eb3b895a8f2e24602f2942da4074b93",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709992,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039c\u03cc\u03c1\u03c6\u03bf\u03c5",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/533/101803533.geojson
+++ b/data/101/803/533/101803533.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Argaka"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3d4e273f2372e97884cd67d08b02af4a",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709984,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u0391\u03c1\u03b3\u03ac\u03ba\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/803/535/101803535.geojson
+++ b/data/101/803/535/101803535.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Pomos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c42f4e35be6bc88c3c38bcfac30a6aad",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709986,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u03a0\u03bf\u03bc\u03cc\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/803/537/101803537.geojson
+++ b/data/101/803/537/101803537.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Kellia, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"14941abb1ceae77b57dba732de036b54",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709991,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039a\u03b5\u03bb\u03bb\u03b9\u03ac",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/539/101803539.geojson
+++ b/data/101/803/539/101803539.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Troulloi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2603eb29b3a69ab0eaa70787efcc8d87",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709991,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u03a4\u03c1\u03bf\u03cd\u03bb\u03bb\u03bf\u03b9",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/541/101803541.geojson
+++ b/data/101/803/541/101803541.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Pyla"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de7303c976bbae8b1d36c111dcbe48bb",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709998,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u03a0\u03cd\u03bb\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/547/101803547.geojson
+++ b/data/101/803/547/101803547.geojson
@@ -115,6 +115,9 @@
         "wd:id":"Q7168940"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4bb3efa30a0ff781a29b85f8c9b76de0",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709997,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u03a0\u03b5\u03c1\u03b9\u03b2\u03cc\u03bb\u03b9\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/549/101803549.geojson
+++ b/data/101/803/549/101803549.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Tersefanou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d02affb10f3f2f82a8adefe5ed8db1db",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709997,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u03a4\u03b5\u03c1\u03c3\u03b5\u03c6\u03ac\u03bd\u03bf\u03c5",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/551/101803551.geojson
+++ b/data/101/803/551/101803551.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Mazotos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fb31f9d2aba32f71d20fb2b769f9a96e",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709984,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039c\u03b1\u03b6\u03c9\u03c4\u03cc\u03c2",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/553/101803553.geojson
+++ b/data/101/803/553/101803553.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Anafotia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a244c39360319769bfd72973536f05b8",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709993,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u0391\u03bd\u03b1\u03c6\u03c9\u03c4\u03af\u03b4\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/555/101803555.geojson
+++ b/data/101/803/555/101803555.geojson
@@ -106,6 +106,9 @@
         "wk:page":"Kivisili"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9fe18e1ae815f532a5e7a36187f2259c",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709992,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039a\u03b9\u03b2\u03b9\u03c3\u03af\u03bb\u03b9",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/557/101803557.geojson
+++ b/data/101/803/557/101803557.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Alethriko"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f95e9bea402013f66b2549d313f8a43b",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709985,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u0391\u03bb\u03b5\u03b8\u03c1\u03b9\u03ba\u03cc",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/559/101803559.geojson
+++ b/data/101/803/559/101803559.geojson
@@ -106,6 +106,9 @@
         "wk:page":"Klavdia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fe4d77ac0e5c1c70349283deae927b3c",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709985,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u039a\u03bb\u03b1\u03c5\u03b4\u03b9\u03ac",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/569/101803569.geojson
+++ b/data/101/803/569/101803569.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Agia Anna, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a8310c29a987155117a6089a135d8bb9",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709984,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u0391\u03b3\u03af\u03b1 \u0386\u03bd\u03bd\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/571/101803571.geojson
+++ b/data/101/803/571/101803571.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Mosfiloti"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"10958a99f475967f64ecf4133314e045",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709997,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039c\u03bf\u03c3\u03c6\u03b9\u03bb\u03c9\u03c4\u03ae",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/573/101803573.geojson
+++ b/data/101/803/573/101803573.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Psevdas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2906d130da7719a482745e8b91907d7f",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709991,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u03a8\u03b5\u03c5\u03b4\u03ac\u03c2",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/575/101803575.geojson
+++ b/data/101/803/575/101803575.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Pyrga, Larnaca"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b64b0312ad68b0d44ea26d1ab9f205bd",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709990,
+    "wof:lastmodified":1582314068,
     "wof:name":"\u03a0\u03c5\u03c1\u03b3\u03ac",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/577/101803577.geojson
+++ b/data/101/803/577/101803577.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Kornos, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"478745151a65eef309e11b9681254d1b",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709998,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039a\u03cc\u03c1\u03bd\u03bf\u03c2",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/579/101803579.geojson
+++ b/data/101/803/579/101803579.geojson
@@ -127,6 +127,9 @@
         "wk:page":"Kofinou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e3a7def970ea8f3d65f7b9b0248c14af",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709998,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039a\u03bf\u03c6\u03af\u03bd\u03bf\u03c5",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/583/101803583.geojson
+++ b/data/101/803/583/101803583.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Lefkara"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d222450cc78c078ca724efae7a0c3569",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709998,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u03a0\u03ac\u03bd\u03c9 \u039b\u03b5\u03cd\u03ba\u03b1\u03c1\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/585/101803585.geojson
+++ b/data/101/803/585/101803585.geojson
@@ -144,6 +144,9 @@
         "wk:page":"Athienou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"73d1c62be2f012c6e40c92f2874981bf",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709997,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u0391\u03b8\u03b9\u03ad\u03bd\u03bf\u03c5",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/803/587/101803587.geojson
+++ b/data/101/803/587/101803587.geojson
@@ -127,6 +127,9 @@
         "wk:page":"Xylotympou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"71597a48991bd655651fdd62d60df491",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709991,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u039e\u03c5\u03bb\u03bf\u03c4\u03cd\u03bc\u03b2\u03bf\u03c5",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/803/591/101803591.geojson
+++ b/data/101/803/591/101803591.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Pergamos, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a46b54e4fdac8f76b203bb0b25e95c2f",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709993,
+    "wof:lastmodified":1582314069,
     "wof:name":"\u03a0\u03ad\u03c1\u03b3\u03b1\u03bc\u03bf\u03c2",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/804/543/101804543.geojson
+++ b/data/101/804/543/101804543.geojson
@@ -103,6 +103,9 @@
         "wk:page":"Pedoulas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"86b278eb11101e7ad772f1adb10348c6",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a0\u03b5\u03b4\u03bf\u03c5\u03bb\u03ac\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/804/545/101804545.geojson
+++ b/data/101/804/545/101804545.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Acheleia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"42214f91b4fd8ba7c059e23b9263d7e3",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u0391\u03c7\u03ad\u03bb\u03b5\u03b9\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/547/101804547.geojson
+++ b/data/101/804/547/101804547.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Tala, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9dc04beb9a3f7b6ffd5ebbad4a08451c",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709983,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a4\u03ac\u03bb\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/549/101804549.geojson
+++ b/data/101/804/549/101804549.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Kissonerga"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e94c4df9cd7e535b45057e93c733fdf",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709983,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039a\u03b9\u03c3\u03c3\u03cc\u03bd\u03b5\u03c1\u03b3\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/551/101804551.geojson
+++ b/data/101/804/551/101804551.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Kouklia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"415104cf01323c7e2ec9835d117d9ed6",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709977,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u039a\u03bf\u03cd\u03ba\u03bb\u03b9\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/555/101804555.geojson
+++ b/data/101/804/555/101804555.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Mandria, Paphos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5fd94adf13d493326f4bffd6fd307da0",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709981,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039c\u03b1\u03bd\u03b4\u03c1\u03b9\u03ac",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/557/101804557.geojson
+++ b/data/101/804/557/101804557.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Timi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cf7196049655411f65fdb5c137a5bb3c",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709978,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a4\u03af\u03bc\u03b7",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/559/101804559.geojson
+++ b/data/101/804/559/101804559.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Anarita"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"60edfe90786a9eb516a6b459c79e51e9",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709977,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0391\u03bd\u03b1\u03c1\u03af\u03c4\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/563/101804563.geojson
+++ b/data/101/804/563/101804563.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Nata, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c10f2dac30e264fe3c4990986688923b",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709981,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039d\u03b1\u03c4\u03ac",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/565/101804565.geojson
+++ b/data/101/804/565/101804565.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Tsada"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b143b99e2ad9220c2a00de0cc40d4842",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709981,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a4\u03c3\u03ac\u03b4\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/569/101804569.geojson
+++ b/data/101/804/569/101804569.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Stroumpi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c947250206b00868d9dc1091bfbc3dc9",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709977,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a3\u03c4\u03c1\u03bf\u03c5\u03bc\u03c0\u03af",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/573/101804573.geojson
+++ b/data/101/804/573/101804573.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Polemi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0c746708e01bf0be52c6d359a261ca5c",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a0\u03bf\u03bb\u03ad\u03bc\u03b9",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/575/101804575.geojson
+++ b/data/101/804/575/101804575.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Kallepia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"097318b1241cfc0a93d28f34eed330fa",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039a\u03b1\u03bb\u03bb\u03ad\u03c0\u03b5\u03b9\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/579/101804579.geojson
+++ b/data/101/804/579/101804579.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Choulou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d60b7e7bcd4c27e096326c00f6a4a6a7",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709983,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a7\u03bf\u03cd\u03bb\u03bf\u03c5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/581/101804581.geojson
+++ b/data/101/804/581/101804581.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Kathikas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1edae861b79d208a6a7267c00b868906",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039a\u03ac\u03b8\u03b9\u03ba\u03b1\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/583/101804583.geojson
+++ b/data/101/804/583/101804583.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Pegeia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4543e5b17c033db5a7f328d6efad810b",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709983,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a0\u03ad\u03b3\u03b5\u03b9\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/585/101804585.geojson
+++ b/data/101/804/585/101804585.geojson
@@ -103,6 +103,9 @@
         "wk:page":"Kelokedara"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d86ce111f8b90b03c11b1f864a668616",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709983,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039a\u03b5\u03bb\u03bf\u03ba\u03ad\u03b4\u03b1\u03c1\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/591/101804591.geojson
+++ b/data/101/804/591/101804591.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q4740228"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"99260f1de3209308f6290c8d52b9cd64",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709981,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u0391\u03bc\u03b1\u03c1\u03b3\u03ad\u03c4\u03b7",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/593/101804593.geojson
+++ b/data/101/804/593/101804593.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Pentalia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c3178774261e1e792d53c9995609bbf6",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709977,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a0\u03b5\u03bd\u03c4\u03b1\u03bb\u03b9\u03ac",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/595/101804595.geojson
+++ b/data/101/804/595/101804595.geojson
@@ -110,6 +110,9 @@
         "wd:id":"Q4343821"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"09f8c7aff4b0a6e82974e7e8f59bbb81",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709977,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a0\u03ac\u03bd\u03c9 \u03a0\u03b1\u03bd\u03b1\u03b3\u03b9\u03ac",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/597/101804597.geojson
+++ b/data/101/804/597/101804597.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Kannaviou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c714c74d4980995223935c23fea2965a",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709981,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039a\u03b1\u03bd\u03bd\u03b1\u03b2\u03b9\u03bf\u03cd",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/605/101804605.geojson
+++ b/data/101/804/605/101804605.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Giolou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c72bd6c9495dc282b894345137580336",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709979,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0393\u03b9\u03cc\u03bb\u03bf\u03c5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/613/101804613.geojson
+++ b/data/101/804/613/101804613.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Terra, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aca3de688f92ad494053c2f1cd2596ba",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709981,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a4\u03ad\u03c1\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/615/101804615.geojson
+++ b/data/101/804/615/101804615.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Polis, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"53710827b4c4bb015183a49292844260",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709982,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a0\u03cc\u03bb\u03b9\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/621/101804621.geojson
+++ b/data/101/804/621/101804621.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Pelathousa"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a2b8dc3d5c4b466ca76593efb8544553",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709978,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a0\u03b5\u03bb\u03b1\u03b8\u03bf\u03cd\u03c3\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/804/623/101804623.geojson
+++ b/data/101/804/623/101804623.geojson
@@ -101,6 +101,9 @@
         "wd:id":"Q4705928"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e8ef7ff9f5089ae49dadf272d6d44508",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709982,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u0391\u03bb\u03b1\u03bc\u03b9\u03bd\u03cc\u03c2",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/804/627/101804627.geojson
+++ b/data/101/804/627/101804627.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Zygi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a7eba4c76f8523214dbc2fd0f762c3a4",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709979,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0396\u03cd\u03b3\u03b9",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/804/629/101804629.geojson
+++ b/data/101/804/629/101804629.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Tochni"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cdb1cd897b3a82314c172ebdb1480ea2",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709979,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a4\u03cc\u03c7\u03bd\u03b7",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/804/631/101804631.geojson
+++ b/data/101/804/631/101804631.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q5104086"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e9a7a18b2d891ebd58542d0808091c56",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709983,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a7\u03bf\u03b9\u03c1\u03bf\u03ba\u03bf\u03b9\u03c4\u03af\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/804/633/101804633.geojson
+++ b/data/101/804/633/101804633.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Psematismenos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0f57d8e937bbc70c45880562ea3f40f2",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709979,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a8\u03b5\u03bc\u03b1\u03c4\u03b9\u03c3\u03bc\u03ad\u03bd\u03bf\u03c2",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/804/635/101804635.geojson
+++ b/data/101/804/635/101804635.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Maroni"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"515abf1a6d66ec24b289029e5036ae0e",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u039c\u03b1\u03c1\u03ce\u03bd\u03b9",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/804/639/101804639.geojson
+++ b/data/101/804/639/101804639.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Skarinou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dae2e4920e24702f61772f7074ddbb1e",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709982,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a3\u03ba\u03b1\u03c1\u03af\u03bd\u03bf\u03c5",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/804/641/101804641.geojson
+++ b/data/101/804/641/101804641.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Ora, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e25e5b8f953d29d86aaa2bad3fa40220",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709982,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039f\u03c1\u03ac",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/804/645/101804645.geojson
+++ b/data/101/804/645/101804645.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Palodeia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a1d52fb5eb06eca2e09869654b0da6e2",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709978,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a0\u03b1\u03bb\u03cc\u03b4\u03b5\u03b9\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/647/101804647.geojson
+++ b/data/101/804/647/101804647.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Apesia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"24bcbb22c2e08ad05813b0a5d1e31313",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709982,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u0391\u03c0\u03b5\u03c3\u03b9\u03ac",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/649/101804649.geojson
+++ b/data/101/804/649/101804649.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Parekklisia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"392d7a3abb96810539d21a06985ed80e",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709981,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a0\u03b1\u03c1\u03b5\u03ba\u03ba\u03bb\u03b7\u03c3\u03b9\u03ac",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/651/101804651.geojson
+++ b/data/101/804/651/101804651.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Pyrgos, Limassol"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"48afe7c1300236626d30d93138df95c2",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101804651,
-    "wof:lastmodified":1566709979,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a0\u03cd\u03c1\u03b3\u03bf\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/653/101804653.geojson
+++ b/data/101/804/653/101804653.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Arakapas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d61f35b104fdd9d8eacee3b19beb170e",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709983,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u0391\u03c1\u03b1\u03ba\u03b1\u03c0\u03ac\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/655/101804655.geojson
+++ b/data/101/804/655/101804655.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Louvaras"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"71e2a2a608de62a220578298fd7ee042",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709982,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039b\u03bf\u03c5\u03b2\u03b1\u03c1\u03ac\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/659/101804659.geojson
+++ b/data/101/804/659/101804659.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Asomatos, Limassol"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"deba54b67573dcba2970c97ebf0d9c12",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0391\u03c3\u03ce\u03bc\u03b1\u03c4\u03bf\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/665/101804665.geojson
+++ b/data/101/804/665/101804665.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Kolossi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e75abb41bb50e5eb8a0d91df9d99ce1",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101804665,
-    "wof:lastmodified":1566709983,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039a\u03bf\u03bb\u03cc\u03c3\u03c3\u03b9",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/667/101804667.geojson
+++ b/data/101/804/667/101804667.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Kantou, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b4f45e2216a20e47af2954251206b6de",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u039a\u03b1\u03bd\u03c4\u03bf\u03cd",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/671/101804671.geojson
+++ b/data/101/804/671/101804671.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Avdimou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5b8c64ba7a3551c62448db2eeb15059b",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709982,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u0391\u03c5\u03b4\u03ae\u03bc\u03bf\u03c5",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/673/101804673.geojson
+++ b/data/101/804/673/101804673.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Anogyra"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0d91c3f84ae7ae9db1d72764f9894b44",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709979,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0391\u03bd\u03ce\u03b3\u03c5\u03c1\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/675/101804675.geojson
+++ b/data/101/804/675/101804675.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Pissouri"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6202e4bdc025a8debfcc3ade521f8ac",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709978,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a0\u03b9\u03c3\u03c3\u03bf\u03cd\u03c1\u03b9",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/681/101804681.geojson
+++ b/data/101/804/681/101804681.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Lofou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9ea055466e3a4a81cc5753be44acb7eb",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709978,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u039b\u03cc\u03c6\u03bf\u03c5",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/683/101804683.geojson
+++ b/data/101/804/683/101804683.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Pachna"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"270e8352fb5f03bd13edfc07ab9520f0",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709982,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a0\u03ac\u03c7\u03bd\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/685/101804685.geojson
+++ b/data/101/804/685/101804685.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Silikou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b214388181b1d2cb21f19d0bfb5cb524",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709982,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a3\u03b9\u03bb\u03af\u03ba\u03bf\u03c5",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/687/101804687.geojson
+++ b/data/101/804/687/101804687.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Agios Mamas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c7add80e5c4bbcdd7a506b21b126dfac",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709979,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u039c\u03ac\u03bc\u03b1\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/693/101804693.geojson
+++ b/data/101/804/693/101804693.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Koilani"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d65023586e4490b66c85f27d2945b8ab",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101804693,
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u039a\u03bf\u03b9\u03bb\u03ac\u03bd\u03b9",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/695/101804695.geojson
+++ b/data/101/804/695/101804695.geojson
@@ -95,6 +95,9 @@
         "wd:id":"Q4831282"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cb064720f92bc0fef4a6cc774e34a225",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u0394\u03b7\u03bc\u03ae\u03c4\u03c1\u03b9\u03bf\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/701/101804701.geojson
+++ b/data/101/804/701/101804701.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Kaminaria"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9ce2eb5659c9eb9b51cb82968ec3e7d7",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709977,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u039a\u03b1\u03bc\u03b9\u03bd\u03ac\u03c1\u03b9\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/703/101804703.geojson
+++ b/data/101/804/703/101804703.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Lemithou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"495576853e074c3d138115bfb129d9eb",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709981,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u039b\u03b5\u03bc\u03af\u03b8\u03bf\u03c5",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/705/101804705.geojson
+++ b/data/101/804/705/101804705.geojson
@@ -128,6 +128,9 @@
         "wk:page":"Platres"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc3c8e451693a0c491ef9f6430e14eb4",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709981,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a0\u03ac\u03bd\u03c9 \u03a0\u03bb\u03ac\u03c4\u03c1\u03b5\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/707/101804707.geojson
+++ b/data/101/804/707/101804707.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Foini"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9256b12e98eee35912342d9e994f3a7d",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709978,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a6\u03bf\u03b9\u03bd\u03af",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/713/101804713.geojson
+++ b/data/101/804/713/101804713.geojson
@@ -106,6 +106,9 @@
         "wk:page":"Pelendri"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25e62fb0abeb2040e5f2c7cc9fe70447",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709980,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u03a0\u03b5\u03bb\u03ad\u03bd\u03b4\u03c1\u03b9",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/717/101804717.geojson
+++ b/data/101/804/717/101804717.geojson
@@ -124,6 +124,9 @@
         "wk:page":"Agros, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"996c0692b624e924e752d768c91ac259",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709983,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u0391\u03b3\u03c1\u03cc\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/804/719/101804719.geojson
+++ b/data/101/804/719/101804719.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Amiantos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6071a7a42428e8f0829f73e7763ae6e9",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709983,
+    "wof:lastmodified":1582314067,
     "wof:name":"\u0391\u03bc\u03af\u03b1\u03bd\u03c4\u03bf\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/837/383/101837383.geojson
+++ b/data/101/837/383/101837383.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Deryneia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d0f4b92b22f634ac13d891d35c92a494",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710012,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0394\u03b5\u03c1\u03cd\u03bd\u03b5\u03b9\u03b1",
     "wof:parent_id":85682389,
     "wof:placetype":"locality",

--- a/data/101/837/387/101837387.geojson
+++ b/data/101/837/387/101837387.geojson
@@ -187,6 +187,9 @@
         "wk:page":"Paralimni"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2db9d61249695e4a2c89be128f946271",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710014,
+    "wof:lastmodified":1582314074,
     "wof:name":"\u03a0\u03b1\u03c1\u03b1\u03bb\u03af\u03bc\u03bd\u03b9",
     "wof:parent_id":85682389,
     "wof:placetype":"locality",

--- a/data/101/837/389/101837389.geojson
+++ b/data/101/837/389/101837389.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Sotira, Famagusta"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0d39bff50533e68275e880cdcc0b0c3a",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710014,
+    "wof:lastmodified":1582314074,
     "wof:name":"\u03a3\u03c9\u03c4\u03ae\u03c1\u03b1",
     "wof:parent_id":85682389,
     "wof:placetype":"locality",

--- a/data/101/837/391/101837391.geojson
+++ b/data/101/837/391/101837391.geojson
@@ -164,6 +164,9 @@
         "wk:page":"Ayia Napa"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc74e5defaca955bd3940e916ce525b0",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0391\u03b3\u03af\u03b1 \u039d\u03ac\u03c0\u03b1",
     "wof:parent_id":85682389,
     "wof:placetype":"locality",

--- a/data/101/837/393/101837393.geojson
+++ b/data/101/837/393/101837393.geojson
@@ -103,6 +103,9 @@
         "wk:page":"Vouno"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1465c8bd441cc5b4d3760f6bcc983e3d",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710013,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0392\u03bf\u03c5\u03bd\u03cc",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/837/397/101837397.geojson
+++ b/data/101/837/397/101837397.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Alampra"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd885841c01acbcf90abffee78f51c1f",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0391\u03bb\u03ac\u03bc\u03c0\u03c1\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/399/101837399.geojson
+++ b/data/101/837/399/101837399.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Nisou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f806dee9af3b7c171680c6f80ad080ca",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039d\u03ae\u03c3\u03bf\u03c5",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/405/101837405.geojson
+++ b/data/101/837/405/101837405.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Dali, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"16e1607db1250fd5b804a0f1d47c30d9",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710014,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0394\u03ac\u03bb\u03b9",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/411/101837411.geojson
+++ b/data/101/837/411/101837411.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Klirou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0cb25f82e2713eda6fbc599e32c85081",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710013,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039a\u03bb\u03ae\u03c1\u03bf\u03c5",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/413/101837413.geojson
+++ b/data/101/837/413/101837413.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Politiko"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba0f21f4207c4e9ba97d6ca34599c0a4",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u03a0\u03bf\u03bb\u03b9\u03c4\u03b9\u03ba\u03cc",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/415/101837415.geojson
+++ b/data/101/837/415/101837415.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q7166855"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b682c02f80bfa931a74f0efcf6c66708",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u03a0\u03ad\u03c1\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/417/101837417.geojson
+++ b/data/101/837/417/101837417.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Psimolofou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"703c9b8e2acaa0064887d2099645299f",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710013,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u03a8\u03b9\u03bc\u03bf\u03bb\u03cc\u03c6\u03bf\u03c5",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/423/101837423.geojson
+++ b/data/101/837/423/101837423.geojson
@@ -104,6 +104,9 @@
         "wd:id":"Q5269500"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"35012597307c7924b920b9b9c551672f",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710012,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u03a0\u03ac\u03bd\u03c9 \u0394\u03b5\u03c5\u03c4\u03b5\u03c1\u03ac",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/425/101837425.geojson
+++ b/data/101/837/425/101837425.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Deftera"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6acb46d1da624007f44398143dcaab2d",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039a\u03ac\u03c4\u03c9 \u0394\u03b5\u03c5\u03c4\u03b5\u03c1\u03ac",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/427/101837427.geojson
+++ b/data/101/837/427/101837427.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Agia Eirini, Nicosia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"266d1784331725b6918b53220276a1f9",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710013,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0391\u03b3\u03af\u03b1 \u0395\u03b9\u03c1\u03ae\u03bd\u03b7",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/429/101837429.geojson
+++ b/data/101/837/429/101837429.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Kannavia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aede18bba87177e58f6d148e28976009",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710013,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039a\u03b1\u03bd\u03bd\u03ac\u03b2\u03b9\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/431/101837431.geojson
+++ b/data/101/837/431/101837431.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Kakopetria"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39a18198c22e3b584be961874ae14de0",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710012,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039a\u03b1\u03ba\u03bf\u03c0\u03b5\u03c4\u03c1\u03b9\u03ac",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/433/101837433.geojson
+++ b/data/101/837/433/101837433.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Galata, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d0f62248ff90c35e4a89f96ed27585b4",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710014,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0393\u03b1\u03bb\u03ac\u03c4\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/437/101837437.geojson
+++ b/data/101/837/437/101837437.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Evrychou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"99da8b9487e532cae98e7de277287571",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710012,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0395\u03c5\u03c1\u03cd\u03c7\u03bf\u03c5",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/441/101837441.geojson
+++ b/data/101/837/441/101837441.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Moutoullas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6f05884a22f24c6573a2e690647eca8",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039c\u03bf\u03c5\u03c4\u03bf\u03c5\u03bb\u03bb\u03ac\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/443/101837443.geojson
+++ b/data/101/837/443/101837443.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Kalopanagiotis"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e52ff1869d90dd95233bf5d703fe99fd",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710013,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039a\u03b1\u03bb\u03bf\u03c0\u03b1\u03bd\u03b1\u03b3\u03b9\u03ce\u03c4\u03b7\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/837/445/101837445.geojson
+++ b/data/101/837/445/101837445.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Marathounta"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea94235f0b4d8a9a6a0cb564ea4fd6e3",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710013,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039c\u03b1\u03c1\u03b1\u03b8\u03bf\u03cd\u03bd\u03c4\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/837/447/101837447.geojson
+++ b/data/101/837/447/101837447.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Armou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fe008f18dd8429aa70a49f586c9149ff",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0386\u03c1\u03bc\u03bf\u03c5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/837/451/101837451.geojson
+++ b/data/101/837/451/101837451.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Lasa, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"41c177634c9446ec620c624e2807cc66",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710014,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039b\u03ac\u03c3\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/837/453/101837453.geojson
+++ b/data/101/837/453/101837453.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Inia, Paphos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e6fdc13dd7a638da800161de009142e",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710012,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u038a\u03bd\u03b5\u03b9\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/837/455/101837455.geojson
+++ b/data/101/837/455/101837455.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Dhrousha"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e8fa6066d0d17e9b4c6b1519ff114bfb",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710012,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0394\u03c1\u03bf\u03cd\u03c3\u03b5\u03b9\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/837/459/101837459.geojson
+++ b/data/101/837/459/101837459.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Kiti, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"26bc6916ceefacc2f0b1b8ff7f77aee8",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710014,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039a\u03af\u03c4\u03b9",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/837/461/101837461.geojson
+++ b/data/101/837/461/101837461.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Dromolaxia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa6828947057fe42a5472cea489eb992",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710014,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0394\u03c1\u03bf\u03bc\u03bf\u03bb\u03b1\u03be\u03b9\u03ac",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/837/463/101837463.geojson
+++ b/data/101/837/463/101837463.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Paramytha"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8b4dae72888a6f10ec327273c37c7432",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710012,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u03a0\u03b1\u03c1\u03b1\u03bc\u03cd\u03b8\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/837/465/101837465.geojson
+++ b/data/101/837/465/101837465.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Spitali"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"83c28c4bfb3add015435e305e5e96d28",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710012,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u03a3\u03c0\u03b9\u03c4\u03ac\u03bb\u03b9",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/837/467/101837467.geojson
+++ b/data/101/837/467/101837467.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Erimi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3d2d6d4067f14cd603a3cfbf889e99b3",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710013,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0395\u03c1\u03ae\u03bc\u03b7",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/837/469/101837469.geojson
+++ b/data/101/837/469/101837469.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Episkopi, Limassol"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5c31a188a21072be83bc847b9a04c33d",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710013,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u0395\u03c0\u03b9\u03c3\u03ba\u03bf\u03c0\u03ae",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/837/471/101837471.geojson
+++ b/data/101/837/471/101837471.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Trimiklini"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d91b195b251a7bc3e0b2562c9ea823c",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u03a4\u03c1\u03b9\u03bc\u03ae\u03ba\u03bb\u03b7\u03bd\u03b7",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/837/473/101837473.geojson
+++ b/data/101/837/473/101837473.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Moniatis"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"08a07802588a81221fd6d442e4e0f2b5",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710013,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039c\u03bf\u03bd\u03b9\u03ac\u03c4\u03b7\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/837/477/101837477.geojson
+++ b/data/101/837/477/101837477.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Mandria, Limassol"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa6309261f9f81c4b89ca826fe623c18",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039c\u03b1\u03bd\u03b4\u03c1\u03b9\u03ac",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/837/479/101837479.geojson
+++ b/data/101/837/479/101837479.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Kato Platres"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d1597237bf5d44b25991faaa4d332a55",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710011,
+    "wof:lastmodified":1582314073,
     "wof:name":"\u039a\u03ac\u03c4\u03c9 \u03a0\u03bb\u03ac\u03c4\u03c1\u03b5\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/838/563/101838563.geojson
+++ b/data/101/838/563/101838563.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Limnia, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"03d1a39fa42cd7a4aae4455461e74e26",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710010,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u039b\u03b9\u03bc\u03bd\u03b9\u03ac",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/838/565/101838565.geojson
+++ b/data/101/838/565/101838565.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Peristeronopigi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa8a8f1c98ce3bcb059e060bc5cfe66a",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566710010,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u03a0\u03b5\u03c1\u03b9\u03c3\u03c4\u03b5\u03c1\u03ce\u03bd\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/838/571/101838571.geojson
+++ b/data/101/838/571/101838571.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Leonarisso"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e924cd08931dfe8311cdb8e328f9f805",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710010,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u039b\u03b5\u03bf\u03bd\u03ac\u03c1\u03b9\u03c3\u03c3\u03bf",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/846/005/101846005.geojson
+++ b/data/101/846/005/101846005.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Agios Sozomenos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dcc14c76f2e8425f49a61eb9c66aa01a",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710003,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u03a3\u03c9\u03b6\u03cc\u03bc\u03b5\u03bd\u03bf\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/846/009/101846009.geojson
+++ b/data/101/846/009/101846009.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Pigenia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"41017e4823dcb36dbe409c5c9ac42ca0",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710003,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u03a0\u03b7\u03b3\u03ad\u03bd\u03b9\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/846/011/101846011.geojson
+++ b/data/101/846/011/101846011.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Steni"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6592282e1894203c9f4946b014561524",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710003,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u03a3\u03c4\u03b5\u03bd\u03ae",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/927/101848927.geojson
+++ b/data/101/848/927/101848927.geojson
@@ -91,6 +91,10 @@
         "wk:page":"Apliki"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1b9172035826fa8ccb4f885d1b95c97",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0391\u03c0\u03bb\u03af\u03ba\u03b9",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/848/929/101848929.geojson
+++ b/data/101/848/929/101848929.geojson
@@ -93,6 +93,10 @@
         "qs_pg:id":1273454
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae1e4fd1f1b363afc5e7f2e433c66943",
     "wof:hierarchy":[
         {
@@ -103,7 +107,7 @@
         }
     ],
     "wof:id":101848929,
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039b\u03ad\u03bc\u03c0\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/931/101848931.geojson
+++ b/data/101/848/931/101848931.geojson
@@ -94,6 +94,10 @@
         "wk:page":"Nikokleia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a169fc559bcbd7b12455af0390aed478",
     "wof:hierarchy":[
         {
@@ -107,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710003,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039d\u03b9\u03ba\u03cc\u03ba\u03bb\u03b5\u03b9\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/933/101848933.geojson
+++ b/data/101/848/933/101848933.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Souskiou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0c8a21a2e0e4abe60a5d77f1e8db233",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101848933,
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a3\u03bf\u03c5\u03c3\u03ba\u03b9\u03bf\u03cd",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/935/101848935.geojson
+++ b/data/101/848/935/101848935.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Agia Varvara, Paphos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4907ad9b45b17a2d70b4e3aedf58ab88",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0391\u03b3\u03af\u03b1 \u0392\u03b1\u03c1\u03b2\u03ac\u03c1\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/937/101848937.geojson
+++ b/data/101/848/937/101848937.geojson
@@ -88,6 +88,10 @@
         "wk:page":"Choletria"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2453d7367cc2ae883f9e342025188201",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a7\u03bf\u03bb\u03b5\u03c4\u03c1\u03b9\u03ac",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/939/101848939.geojson
+++ b/data/101/848/939/101848939.geojson
@@ -95,6 +95,10 @@
         "wk:page":"Akoursos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"af9bac9e7b69c0ed71e6699228f8bc5d",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710003,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0391\u03ba\u03bf\u03c5\u03c1\u03c3\u03cc\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/943/101848943.geojson
+++ b/data/101/848/943/101848943.geojson
@@ -94,6 +94,10 @@
         "wk:page":"Archimandrita"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c04b3ac0d46b8e4690fec1f93e741c6c",
     "wof:hierarchy":[
         {
@@ -107,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a0\u03ac\u03bd\u03c9 \u0391\u03c1\u03c7\u03b9\u03bc\u03b1\u03bd\u03b4\u03c1\u03af\u03c4\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/945/101848945.geojson
+++ b/data/101/848/945/101848945.geojson
@@ -97,6 +97,10 @@
         "wk:page":"Stavrokonnou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3c3c6d227acfd1bb0201e87d36c4767",
     "wof:hierarchy":[
         {
@@ -110,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a3\u03c4\u03b1\u03c5\u03c1\u03bf\u03ba\u03cc\u03bd\u03bd\u03bf\u03c5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/947/101848947.geojson
+++ b/data/101/848/947/101848947.geojson
@@ -88,6 +88,10 @@
         "wk:page":"Trachypedoula"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c799ad51564019f25ab58ca180de0a76",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a4\u03c1\u03b1\u03c7\u03c5\u03c0\u03ad\u03b4\u03bf\u03c5\u03bb\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/949/101848949.geojson
+++ b/data/101/848/949/101848949.geojson
@@ -87,6 +87,10 @@
         "wk:page":"Salamiou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3b798fb2779f88e9d1d581e9fc9261b",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a3\u03b1\u03bb\u03b1\u03bc\u03b9\u03bf\u03cd",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/951/101848951.geojson
+++ b/data/101/848/951/101848951.geojson
@@ -92,6 +92,10 @@
         "wk:page":"Kidasi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a7a8617d1d48c130baa5b8a508363d7",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039a\u03b9\u03b4\u03ac\u03c3\u03b9",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/953/101848953.geojson
+++ b/data/101/848/953/101848953.geojson
@@ -82,6 +82,10 @@
         "wk:page":"Mesana"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90ff4cfe1e39e986d4a3684292a5160b",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710003,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039c\u03ad\u03c3\u03b1\u03bd\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/955/101848955.geojson
+++ b/data/101/848/955/101848955.geojson
@@ -81,6 +81,10 @@
         "wk:page":"Arminou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6a26211b93483726b47f7039c906da3",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0391\u03c1\u03bc\u03af\u03bd\u03bf\u03c5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/957/101848957.geojson
+++ b/data/101/848/957/101848957.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q4818374"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cec30ef281e9b928d0f70f414975aa4d",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0391\u03b3\u03af\u03b1 \u039c\u03b1\u03c1\u03af\u03bd\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/961/101848961.geojson
+++ b/data/101/848/961/101848961.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Faleia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81de55955f6b5cc5d5c57efe6b880566",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a6\u03ac\u03bb\u03b5\u03b9\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/963/101848963.geojson
+++ b/data/101/848/963/101848963.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Statos\u2013Agios Fotios"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e71443f09963a12affd9319fee2a62c",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101848963,
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a3\u03c4\u03b1\u03c4\u03cc\u03c2-\u02bc\u03b3\u03b9\u03bf\u03c2 \u03a6\u03ce\u03c4\u03b9\u03bf\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/965/101848965.geojson
+++ b/data/101/848/965/101848965.geojson
@@ -86,6 +86,10 @@
         "wk:page":"Kritou Marottou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b3d31519a0901bc9a0cb6d356c7d794",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710003,
+    "wof:lastmodified":1582314070,
     "wof:name":"\u039a\u03c1\u03af\u03c4\u03bf\u03c5 \u039c\u03b1\u03c1\u03cc\u03c4\u03c4\u03bf\u03c5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/967/101848967.geojson
+++ b/data/101/848/967/101848967.geojson
@@ -91,6 +91,10 @@
         "wk:page":"Drymou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9fe107a398e4a4cbb15e4c9989c07882",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0394\u03c1\u03cd\u03bc\u03bf\u03c5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/969/101848969.geojson
+++ b/data/101/848/969/101848969.geojson
@@ -87,6 +87,10 @@
         "wk:page":"Theletra"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"70d86a63d6adc070159c4bcbfc66ef22",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0398\u03b5\u03bb\u03ad\u03c4\u03c1\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/971/101848971.geojson
+++ b/data/101/848/971/101848971.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Pitargou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6bcfa69983aba93c2fd66cadcb6ddf7",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a0\u03b9\u03c4\u03b1\u03c1\u03b3\u03bf\u03cd",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/973/101848973.geojson
+++ b/data/101/848/973/101848973.geojson
@@ -75,6 +75,9 @@
         "wk:page":"Mousere"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2ffa907521c0a1988dbfabde882bb51a",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039c\u03bf\u03cd\u03c3\u03b5\u03c1\u03b5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/975/101848975.geojson
+++ b/data/101/848/975/101848975.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Maronas, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9739003e5bf7601ed97055530653368b",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039c\u03ac\u03c1\u03c9\u03bd\u03b1\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/979/101848979.geojson
+++ b/data/101/848/979/101848979.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":9
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48e028b66edb37b5ea2dfcc656060845",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101848979,
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a0\u03c1\u03b1\u03c3\u03c4\u03b9\u03cc",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/981/101848981.geojson
+++ b/data/101/848/981/101848981.geojson
@@ -85,6 +85,9 @@
         "wd:id":"Q7942718"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07b15740f4bb01f422b36da7cc2b7cd2",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101848981,
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0392\u03c1\u03ad\u03c4\u03c3\u03b9\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/983/101848983.geojson
+++ b/data/101/848/983/101848983.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Lapithiou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ad6672ae006a53f45b97cc7b6d025d3",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039b\u03b1\u03c0\u03b7\u03b8\u03b9\u03bf\u03cd",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/985/101848985.geojson
+++ b/data/101/848/985/101848985.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Foinikas, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48237b56c3e2841d5d6f50722d86d24a",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a6\u03bf\u03af\u03bd\u03b9\u03ba\u03b1\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/848/987/101848987.geojson
+++ b/data/101/848/987/101848987.geojson
@@ -99,6 +99,10 @@
         "wk:page":"Softades"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e86147637dbf7f14fb2ca6aca2109f5",
     "wof:hierarchy":[
         {
@@ -112,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a3\u03bf\u03c6\u03c4\u03ac\u03b4\u03b5\u03c2",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/848/989/101848989.geojson
+++ b/data/101/848/989/101848989.geojson
@@ -103,6 +103,10 @@
         "wd:id":"Q6817236"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"375b5bc10cfca4e05a62aaed44947721",
     "wof:hierarchy":[
         {
@@ -116,7 +120,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039c\u03b5\u03bd\u03cc\u03b3\u03b5\u03b9\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/848/991/101848991.geojson
+++ b/data/101/848/991/101848991.geojson
@@ -90,6 +90,9 @@
         "wd:id":"Q747896"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4ad2c081362aa9ad2fb7484ba1b4bee",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710003,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0394\u03b5\u03bb\u03af\u03ba\u03b7\u03c0\u03bf\u03c2",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/848/993/101848993.geojson
+++ b/data/101/848/993/101848993.geojson
@@ -105,6 +105,10 @@
         "wk:page":"Mari, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c476ca22705bcf90bddb930b35238ca",
     "wof:hierarchy":[
         {
@@ -118,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710005,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039c\u03b1\u03c1\u03af",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/848/997/101848997.geojson
+++ b/data/101/848/997/101848997.geojson
@@ -105,6 +105,10 @@
         "wk:page":"Kalavasos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"460830b92ecf0e8b10d5c4f08cf3a35f",
     "wof:hierarchy":[
         {
@@ -118,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039a\u03b1\u03bb\u03b1\u03b2\u03b1\u03c3\u03cc\u03c2",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/848/999/101848999.geojson
+++ b/data/101/848/999/101848999.geojson
@@ -98,6 +98,10 @@
         "wk:page":"Vavla"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1af524cc7b4375837ea9a1fb66178795",
     "wof:hierarchy":[
         {
@@ -111,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710004,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0392\u03ac\u03b2\u03bb\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/849/001/101849001.geojson
+++ b/data/101/849/001/101849001.geojson
@@ -96,6 +96,10 @@
         "wk:page":"Lageia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c73fb6c95c474613a8f1c04846f3e21c",
     "wof:hierarchy":[
         {
@@ -109,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u039b\u03ac\u03b3\u03b5\u03b9\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/849/003/101849003.geojson
+++ b/data/101/849/003/101849003.geojson
@@ -92,6 +92,10 @@
         "wk:page":"Melini"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"75c96087e5d1e9d38af6057c8b1cf0e8",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
         }
     ],
     "wof:id":101849003,
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u039c\u03b5\u03bb\u03af\u03bd\u03b7",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/849/005/101849005.geojson
+++ b/data/101/849/005/101849005.geojson
@@ -100,6 +100,10 @@
         "wk:page":"Odou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"15d4d3f728a7d21b94487c285d60c23b",
     "wof:hierarchy":[
         {
@@ -113,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710009,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u039f\u03b4\u03bf\u03cd",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/849/007/101849007.geojson
+++ b/data/101/849/007/101849007.geojson
@@ -106,6 +106,9 @@
         "wd:id":"Q4692596"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d8aef03c9ac895ae4d7df134fa8f8e6",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0391\u03b3\u03af\u03bf\u03b9 \u0392\u03b1\u03b2\u03b1\u03c4\u03c3\u03b9\u03bd\u03b9\u03ac\u03c2",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/849/009/101849009.geojson
+++ b/data/101/849/009/101849009.geojson
@@ -95,6 +95,10 @@
         "wk:page":"Vavatsinia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"38a0f7a37639102e95730d6d78a14dcb",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0392\u03b1\u03b2\u03b1\u03c4\u03c3\u03b9\u03bd\u03b9\u03ac",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/849/011/101849011.geojson
+++ b/data/101/849/011/101849011.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Fasoula, Limassol"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b23d794224ebc6318df152eb697772d7",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u03a6\u03b1\u03c3\u03bf\u03cd\u03bb\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/015/101849015.geojson
+++ b/data/101/849/015/101849015.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Mathikoloni"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f20d8a4559ae83157f21978f7b0b0c49",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101849015,
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039c\u03b1\u03b8\u03b9\u03ba\u03bf\u03bb\u03ce\u03bd\u03b7",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/017/101849017.geojson
+++ b/data/101/849/017/101849017.geojson
@@ -84,6 +84,10 @@
         "wk:page":"Gerasa, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"47558df6b05260cad3356b4768265602",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0393\u03b5\u03c1\u03ac\u03c3\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/019/101849019.geojson
+++ b/data/101/849/019/101849019.geojson
@@ -94,6 +94,10 @@
         "wk:page":"Apsiou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74d28ac91ef02fd2979cb2d03d142ff0",
     "wof:hierarchy":[
         {
@@ -107,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0391\u03c8\u03b9\u03bf\u03cd",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/021/101849021.geojson
+++ b/data/101/849/021/101849021.geojson
@@ -93,6 +93,10 @@
         "wk:page":"Korfi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9df478804281eb68c547a9cefcb48a80",
     "wof:hierarchy":[
         {
@@ -106,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u039a\u03bf\u03c1\u03c6\u03ae",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/023/101849023.geojson
+++ b/data/101/849/023/101849023.geojson
@@ -90,6 +90,10 @@
         "wk:page":"Limnatis, Limassol"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a739e5aa02c35a8be2b002b78b2dd00b",
     "wof:hierarchy":[
         {
@@ -103,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039b\u03b9\u03bc\u03bd\u03ac\u03c4\u03b7\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/025/101849025.geojson
+++ b/data/101/849/025/101849025.geojson
@@ -88,6 +88,10 @@
         "wk:page":"Kapilio"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b7bf5b0b621bbe423c48b40909f5efd",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039a\u03b1\u03c0\u03b7\u03bb\u03b5\u03b9\u03cc",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/027/101849027.geojson
+++ b/data/101/849/027/101849027.geojson
@@ -98,6 +98,10 @@
         "wk:page":"Armenochori, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5935018306c736cc295dedd09a8dba90",
     "wof:hierarchy":[
         {
@@ -111,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0391\u03c1\u03bc\u03b5\u03bd\u03bf\u03c7\u03ce\u03c1\u03b9",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/029/101849029.geojson
+++ b/data/101/849/029/101849029.geojson
@@ -95,6 +95,10 @@
         "wk:page":"Foinikaria"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4ec3793c444864f3e618bc8c38a302d",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u03a6\u03bf\u03b9\u03bd\u03b9\u03ba\u03ac\u03c1\u03b9\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/033/101849033.geojson
+++ b/data/101/849/033/101849033.geojson
@@ -104,6 +104,10 @@
         "wk:page":"Akrounta"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ec01a03711dfbd063b84357d97b5749",
     "wof:hierarchy":[
         {
@@ -117,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710009,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0391\u03ba\u03c1\u03bf\u03cd\u03bd\u03c4\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/035/101849035.geojson
+++ b/data/101/849/035/101849035.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Pentakomo"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7ffc4298df05926654765adb0377698",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101849035,
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u03a0\u03b5\u03bd\u03c4\u03ac\u03ba\u03c9\u03bc\u03bf",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/037/101849037.geojson
+++ b/data/101/849/037/101849037.geojson
@@ -92,6 +92,10 @@
         "wk:page":"Asgata"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d577e04191bf8583a1b6693ae9b186ff",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0391\u03c3\u03b3\u03ac\u03c4\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/039/101849039.geojson
+++ b/data/101/849/039/101849039.geojson
@@ -59,6 +59,9 @@
         "qs_pg:id":4
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fecc63b83b8b7e0149cac10b5e14007c",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":101849039,
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0392\u03ac\u03c3\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/041/101849041.geojson
+++ b/data/101/849/041/101849041.geojson
@@ -84,6 +84,10 @@
         "wk:page":"Sanida"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"eee584c0cc62eb6975b23a1834e5a9cf",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a3\u03b1\u03bd\u03af\u03b4\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/043/101849043.geojson
+++ b/data/101/849/043/101849043.geojson
@@ -95,6 +95,10 @@
         "wk:page":"Eptagoneia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b59b8db1ffd8a491cb03eaf184e782d2",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0395\u03c0\u03c4\u03b1\u03b3\u03ce\u03bd\u03b5\u03b9\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/045/101849045.geojson
+++ b/data/101/849/045/101849045.geojson
@@ -93,6 +93,10 @@
         "wk:page":"Dierona"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e39102704097fd13781735608d7aba5e",
     "wof:hierarchy":[
         {
@@ -106,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0394\u03b9\u03b5\u03c1\u03ce\u03bd\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/047/101849047.geojson
+++ b/data/101/849/047/101849047.geojson
@@ -108,6 +108,10 @@
         "wk:page":"Agios Pavlos, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ea9953ba8ac88bf68e186a48f02b909",
     "wof:hierarchy":[
         {
@@ -121,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u03a0\u03ac\u03c5\u03bb\u03bf\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/051/101849051.geojson
+++ b/data/101/849/051/101849051.geojson
@@ -104,6 +104,10 @@
         "wd:id":"Q4831295"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"809aba9c14e53a72b59864f5354b21b0",
     "wof:hierarchy":[
         {
@@ -117,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710009,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u039a\u03c9\u03bd\u03c3\u03c4\u03b1\u03bd\u03c4\u03af\u03bd\u03bf\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/053/101849053.geojson
+++ b/data/101/849/053/101849053.geojson
@@ -86,6 +86,10 @@
         "wk:page":"Sykopetra"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"747ad459374f2a417e23b21ac2bfd101",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u03a3\u03c5\u03ba\u03cc\u03c0\u03b5\u03c4\u03c1\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/055/101849055.geojson
+++ b/data/101/849/055/101849055.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":2
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"368b174d47a9b032cc1b4d995cac5736",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101849055,
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u039a\u03b1\u03bb\u03cc \u03a7\u03c9\u03c1\u03b9\u03cc",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/057/101849057.geojson
+++ b/data/101/849/057/101849057.geojson
@@ -99,6 +99,10 @@
         "wk:page":"Zoopigi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"46e24ee19649b362032bebbc95dbad1b",
     "wof:hierarchy":[
         {
@@ -112,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0396\u03c9\u03bf\u03c0\u03b7\u03b3\u03ae",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/059/101849059.geojson
+++ b/data/101/849/059/101849059.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":8
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd414007c8d6b2a781cb6af7a156111e",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101849059,
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u03a4\u03c3\u03b5\u03c1\u03ba\u03ad\u03b6\u03bf\u03b9",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/061/101849061.geojson
+++ b/data/101/849/061/101849061.geojson
@@ -105,6 +105,10 @@
         "wk:page":"Sotira, Limassol"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8991889375a4de2dd131a3b4fb44debd",
     "wof:hierarchy":[
         {
@@ -118,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u03a3\u03c9\u03c4\u03ae\u03c1\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/063/101849063.geojson
+++ b/data/101/849/063/101849063.geojson
@@ -72,6 +72,9 @@
         "wk:page":"Paramali"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab68798a7e6744b9206722afdf4e1518",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":101849063,
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u03a0\u03b1\u03c1\u03b1\u03bc\u03ac\u03bb\u03b9",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/065/101849065.geojson
+++ b/data/101/849/065/101849065.geojson
@@ -100,6 +100,10 @@
         "wk:page":"Alektora"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c861b4dfdb640dece2c0a55d4c08f73",
     "wof:hierarchy":[
         {
@@ -113,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0391\u03bb\u03ad\u03ba\u03c4\u03bf\u03c1\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/069/101849069.geojson
+++ b/data/101/849/069/101849069.geojson
@@ -113,6 +113,10 @@
         "wk:page":"Alassa"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ee34f7927f23d8a0e785d6d9f918ca58",
     "wof:hierarchy":[
         {
@@ -126,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710009,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0386\u03bb\u03b1\u03c3\u03c3\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/071/101849071.geojson
+++ b/data/101/849/071/101849071.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":2
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d7f390d14735662f8d525d2d3165b42",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u039a\u03ac\u03c4\u03c9 \u039a\u03b9\u03b2\u03af\u03b4\u03b5\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/073/101849073.geojson
+++ b/data/101/849/073/101849073.geojson
@@ -102,6 +102,10 @@
         "wk:page":"Agios Amvrosios, Limassol"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"65ec17d19b15d4776f78b581415bb118",
     "wof:hierarchy":[
         {
@@ -115,7 +119,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u0391\u03bc\u03b2\u03c1\u03cc\u03c3\u03b9\u03bf\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/075/101849075.geojson
+++ b/data/101/849/075/101849075.geojson
@@ -105,6 +105,10 @@
         "wk:page":"Agios Therapon"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9569ebe00900a909b3d3b79030d9f42d",
     "wof:hierarchy":[
         {
@@ -118,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u0398\u03b5\u03c1\u03ac\u03c0\u03c9\u03bd",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/077/101849077.geojson
+++ b/data/101/849/077/101849077.geojson
@@ -61,6 +61,9 @@
         "qs_pg:id":405504
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6224c39942bebe0c95ed5db795c30364",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":101849077,
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0394\u03c9\u03c1\u03ac",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/079/101849079.geojson
+++ b/data/101/849/079/101849079.geojson
@@ -102,6 +102,10 @@
         "wk:page":"Vouni"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec166d72d2a509d60bce75a82dc3f75c",
     "wof:hierarchy":[
         {
@@ -115,7 +119,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u0392\u03bf\u03c5\u03bd\u03af",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/081/101849081.geojson
+++ b/data/101/849/081/101849081.geojson
@@ -95,6 +95,10 @@
         "wk:page":"Omodos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7601c616bc8f918a268959131a3a142",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710008,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u038c\u03bc\u03bf\u03b4\u03bf\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/083/101849083.geojson
+++ b/data/101/849/083/101849083.geojson
@@ -92,6 +92,10 @@
         "wk:page":"Palaiomylos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c00eeb10393e366de92ffe81ba8fde8c",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u03a0\u03b1\u03bb\u03b1\u03b9\u03cc\u03bc\u03c5\u03bb\u03bf\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/087/101849087.geojson
+++ b/data/101/849/087/101849087.geojson
@@ -86,6 +86,10 @@
         "wk:page":"Treis Elies"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2db72d8006f67afa25ef7f7ca8f4aef",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
         }
     ],
     "wof:id":101849087,
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u03a4\u03c1\u03b5\u03af\u03c2 \u0395\u03bb\u03b9\u03ad\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/089/101849089.geojson
+++ b/data/101/849/089/101849089.geojson
@@ -84,6 +84,10 @@
         "wk:page":"Kato Mylos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6c3d06fb55ff44c60925e645d502a743",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u039a\u03ac\u03c4\u03c9 \u039c\u03cd\u03bb\u03bf\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/091/101849091.geojson
+++ b/data/101/849/091/101849091.geojson
@@ -106,6 +106,10 @@
         "wk:page":"Kyperounta"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f2e82fc12b5675b4584e9371f143cbc5",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710007,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u039a\u03c5\u03c0\u03b5\u03c1\u03bf\u03cd\u03bd\u03c4\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/849/093/101849093.geojson
+++ b/data/101/849/093/101849093.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q5552475"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ab790b17103c242de92cecfc6828c63",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710009,
+    "wof:lastmodified":1582314072,
     "wof:name":"\u0393\u03b5\u03c1\u03bf\u03b2\u03ac\u03c3\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/850/051/101850051.geojson
+++ b/data/101/850/051/101850051.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Kanli"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d7f333fff77e62e0b334b1f4e9b51ba",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":101850051,
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u039a\u03b1\u03bd\u03bb\u03af",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/053/101850053.geojson
+++ b/data/101/850/053/101850053.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Achna"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"afe21828e93c0a0a3f8c3d5f45f356fb",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":101850053,
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0386\u03c7\u03bd\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/055/101850055.geojson
+++ b/data/101/850/055/101850055.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Aloda"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f8c1d423010dbf1ff31653c5b419a04",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0391\u03bb\u03cc\u03b4\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/059/101850059.geojson
+++ b/data/101/850/059/101850059.geojson
@@ -76,6 +76,9 @@
         "wk:page":"Perivolia tou Trikomou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"441cc4584a1e8c5d0ec2a15650a3a85c",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101850059,
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a0\u03b5\u03c1\u03b9\u03b2\u03cc\u03bb\u03b9\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/061/101850061.geojson
+++ b/data/101/850/061/101850061.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Santalaris"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d76bf6659847dbba63e75a9f5063727",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a3\u03b1\u03bd\u03c4\u03b1\u03bb\u03ac\u03c1\u03b7\u03c2",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/063/101850063.geojson
+++ b/data/101/850/063/101850063.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Maratha, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"607efab951b6bd7c5b2741a9eb14d2fd",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039c\u03ac\u03c1\u03b1\u03b8\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/065/101850065.geojson
+++ b/data/101/850/065/101850065.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Goufes"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc7ec55f0a7bbda0f877390fcab98e5e",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709973,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0393\u03bf\u03cd\u03c6\u03b5\u03c2",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/067/101850067.geojson
+++ b/data/101/850/067/101850067.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Artemi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d478812bd991e67fc0bc0bd40e0affc",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0391\u03c1\u03c4\u03ad\u03bc\u03b9",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/069/101850069.geojson
+++ b/data/101/850/069/101850069.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":9
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"accee76aa6b0fe4fa0d9cb32f55ca922",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101850069,
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u039d\u03b9\u03ba\u03cc\u03bb\u03b1\u03bf\u03c2",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/071/101850071.geojson
+++ b/data/101/850/071/101850071.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Gerani, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"724448b57753b83119ed5c3652a8a439",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709973,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0393\u03b5\u03c1\u03ac\u03bd\u03b9",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/073/101850073.geojson
+++ b/data/101/850/073/101850073.geojson
@@ -90,6 +90,9 @@
         "wd:id":"Q6811166"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"83a099dd518f55e2a5eaa47af9d99223",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039c\u03b5\u03bb\u03ac\u03bd\u03b1\u03c1\u03b3\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/077/101850077.geojson
+++ b/data/101/850/077/101850077.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Krini, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"88696defe1cccb02eca84fe06c3fead8",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709973,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03c1\u03b7\u03bd\u03af",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/079/101850079.geojson
+++ b/data/101/850/079/101850079.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Pileri"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"27407b3502490514380d305810ac4674",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101850079,
-    "wof:lastmodified":1566709973,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u03a0\u03b9\u03bb\u03ad\u03c1\u03b9",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/081/101850081.geojson
+++ b/data/101/850/081/101850081.geojson
@@ -61,6 +61,9 @@
         "qs_pg:id":9
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1cb546a15eeab51816427163467b774e",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101850081,
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03b9\u03bf\u03bc\u03bf\u03c5\u03c1\u03c4\u03b6\u03bf\u03cd",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/083/101850083.geojson
+++ b/data/101/850/083/101850083.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Asomatos, Kyrenia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7ef17a65b803ac485a6f47f49bc4acad",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709973,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0391\u03c3\u03ce\u03bc\u03b1\u03c4\u03bf\u03c2",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/085/101850085.geojson
+++ b/data/101/850/085/101850085.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Karpaseia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"491dbc2f0d84cf4331d0b86ceab94c07",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709973,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03b1\u03c1\u03c0\u03ac\u03c3\u03b5\u03b9\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/087/101850087.geojson
+++ b/data/101/850/087/101850087.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Livera"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b4ec74ba6236e939427e6bc7afd28a4",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039b\u03b9\u03b2\u03b5\u03c1\u03ac",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/089/101850089.geojson
+++ b/data/101/850/089/101850089.geojson
@@ -96,6 +96,10 @@
         "wk:page":"Trapeza, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dee8127711e250805910945c97031da8",
     "wof:hierarchy":[
         {
@@ -131,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u03a4\u03c1\u03ac\u03c0\u03b5\u03b6\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/091/101850091.geojson
+++ b/data/101/850/091/101850091.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Ftericha"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"14c4a2ac4a7d7a5653654203c69617f2",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u03a6\u03c4\u03ad\u03c1\u03b9\u03c7\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/095/101850095.geojson
+++ b/data/101/850/095/101850095.geojson
@@ -50,6 +50,9 @@
         "qs_pg:id":9
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30242117c2e1dcafa72e7c023fdd7764",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":101850095,
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u039b\u03ac\u03c1\u03bd\u03b1\u03ba\u03b1\u03c2 \u039b\u03b1\u03c0\u03ae\u03b8\u03bf\u03c5",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/097/101850097.geojson
+++ b/data/101/850/097/101850097.geojson
@@ -84,6 +84,10 @@
         "wd:id":"Q18209601"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"89aa47e0f0e78131a04e82e51ea7c326",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u03a0\u03ac\u03bd\u03b1\u03b3\u03c1\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/099/101850099.geojson
+++ b/data/101/850/099/101850099.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Orga, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"926a4c1773396f1637dc4d2802a7bbf0",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u038c\u03c1\u03b3\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/101/101850101.geojson
+++ b/data/101/850/101/101850101.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Ampelikou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3294af248717dbdd033bb9d8a201e976",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0391\u03bc\u03c0\u03b5\u03bb\u03b9\u03ba\u03bf\u03cd",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/103/101850103.geojson
+++ b/data/101/850/103/101850103.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Peristeronari"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f4da285f9e9fcee6862335247d1fa4f",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709972,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u03a0\u03b5\u03c1\u03b9\u03c3\u03c4\u03b5\u03c1\u03c9\u03bd\u03ac\u03c1\u03b9",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/105/101850105.geojson
+++ b/data/101/850/105/101850105.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Kotsiatis"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"39db33a9b6ab5d62ff22e098533464c6",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101850105,
-    "wof:lastmodified":1566709972,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03bf\u03c4\u03c3\u03b9\u03ac\u03c4\u03b7\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/107/101850107.geojson
+++ b/data/101/850/107/101850107.geojson
@@ -91,6 +91,10 @@
         "wk:page":"Margi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b0886f4f1f5829e70d6b8d456ee04954",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039c\u03b1\u03c1\u03b3\u03af",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/109/101850109.geojson
+++ b/data/101/850/109/101850109.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":5
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0230970526a6858c6d86d3083a4305a6",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101850109,
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u0393\u03b5\u03ce\u03c1\u03b3\u03b9\u03bf\u03c2 \u039a\u03b1\u03c5\u03ba\u03ac\u03bb\u03bb\u03bf\u03c5",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/113/101850113.geojson
+++ b/data/101/850/113/101850113.geojson
@@ -93,6 +93,10 @@
         "wk:page":"Spilia, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7719b3fe6292027a76bf33ea890c72f5",
     "wof:hierarchy":[
         {
@@ -106,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a3\u03c0\u03ae\u03bb\u03b9\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/115/101850115.geojson
+++ b/data/101/850/115/101850115.geojson
@@ -97,6 +97,9 @@
         "wd:id":"Q4831305"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee474807342135335e80e7b1b015a380",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u0398\u03b5\u03cc\u03b4\u03c9\u03c1\u03bf\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/117/101850117.geojson
+++ b/data/101/850/117/101850117.geojson
@@ -85,6 +85,10 @@
         "wk:page":"Kaliana"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0d7b792f54c46995cfcd9765d8851196",
     "wof:hierarchy":[
         {
@@ -98,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03b1\u03bb\u03b9\u03ac\u03bd\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/119/101850119.geojson
+++ b/data/101/850/119/101850119.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Mylikouri"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"987b2162f2aa24fc96cf87f4874e31d4",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101850119,
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039c\u03c5\u03bb\u03b9\u03ba\u03bf\u03cd\u03c1\u03b9",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/121/101850121.geojson
+++ b/data/101/850/121/101850121.geojson
@@ -98,6 +98,10 @@
         "wk:page":"Oikos, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f36179cb909c7edc511b641cb5a001b2",
     "wof:hierarchy":[
         {
@@ -111,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039f\u03af\u03ba\u03bf\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/123/101850123.geojson
+++ b/data/101/850/123/101850123.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Tsakistra"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c6dd78c64eaf53f4196b518a8aeec5d",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101850123,
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a4\u03c3\u03b1\u03ba\u03af\u03c3\u03c4\u03c1\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/125/101850125.geojson
+++ b/data/101/850/125/101850125.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Pachyammos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"abfb3e6beffc965e410f4d3ebfce98ad",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101850125,
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u03a0\u03b1\u03c7\u03cd\u03b1\u03bc\u03bc\u03bf\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/127/101850127.geojson
+++ b/data/101/850/127/101850127.geojson
@@ -95,6 +95,9 @@
         "wd:id":"Q4831308"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"878f4e015a9865c0aac2ccac6269529c",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101850127,
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u0398\u03b5\u03cc\u03b4\u03c9\u03c1\u03bf\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/131/101850131.geojson
+++ b/data/101/850/131/101850131.geojson
@@ -81,6 +81,9 @@
         "wk:page":"Dyo Potamoi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c4ed6d95a347bf818cd4e48091fed781",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0394\u03cd\u03bf \u03a0\u03bf\u03c4\u03b1\u03bc\u03bf\u03af",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/133/101850133.geojson
+++ b/data/101/850/133/101850133.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q4818039"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c31a5fc3f6986704eb7b858d0d1e82ca",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709972,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0391\u03c5\u03bb\u03ce\u03bd\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/135/101850135.geojson
+++ b/data/101/850/135/101850135.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Masari"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c6eda9f6a17d3de4df4b57b25ebab01b",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709972,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039c\u03ac\u03c3\u03b1\u03c1\u03b7",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/137/101850137.geojson
+++ b/data/101/850/137/101850137.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Petra, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4effaba1584e58bf870712cda8ddbe4b",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u03a0\u03ad\u03c4\u03c1\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/139/101850139.geojson
+++ b/data/101/850/139/101850139.geojson
@@ -74,6 +74,9 @@
         "wk:page":"Kataliontas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45a5477e7564fcaeeacfc085e9fdf95c",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":101850139,
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03b1\u03c4\u03b1\u03bb\u03b9\u03cc\u03bd\u03c4\u03b1\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/141/101850141.geojson
+++ b/data/101/850/141/101850141.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q18712727"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"208b3e10a2cf1fffd2c8d2a756c9f720",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709976,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03b9 \u0397\u03bb\u03b9\u03cc\u03c6\u03c9\u03c4\u03bf\u03b9",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/143/101850143.geojson
+++ b/data/101/850/143/101850143.geojson
@@ -121,6 +121,9 @@
         "wk:page":"Kokkina"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7c6ff09e0fbb165b7d86d3d7b83503d",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03cc\u03ba\u03ba\u03b9\u03bd\u03b1",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/850/145/101850145.geojson
+++ b/data/101/850/145/101850145.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Vroisha"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d614fbc6f60dad29524466b2b7a5652b",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u03a6\u03c1\u03bf\u03b4\u03af\u03c3\u03b9\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/850/149/101850149.geojson
+++ b/data/101/850/149/101850149.geojson
@@ -95,6 +95,10 @@
         "wk:page":"Anadiou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf404c8319f3fcdfdbeb87352a0e731c",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709977,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0391\u03bd\u03b1\u03b4\u03b9\u03bf\u03cd",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/850/151/101850151.geojson
+++ b/data/101/850/151/101850151.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Kritou Terra"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d83280108f7284bb196489cb05d6c35b",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101850151,
-    "wof:lastmodified":1566709973,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03c1\u03af\u03c4\u03bf\u03c5 \u03a4\u03ad\u03c1\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/850/153/101850153.geojson
+++ b/data/101/850/153/101850153.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Arodes"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed878d10bdec95037e133db1eeeea9fa",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03ac\u03c4\u03c9 \u0391\u03c1\u03cc\u03b4\u03b5\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/850/155/101850155.geojson
+++ b/data/101/850/155/101850155.geojson
@@ -93,6 +93,10 @@
         "wk:page":"Androlykou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5a7d1f3e4c7df8c3e2c0eab3e80671c",
     "wof:hierarchy":[
         {
@@ -106,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u0391\u03bd\u03b4\u03c1\u03bf\u03bb\u03af\u03ba\u03bf\u03c5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/850/157/101850157.geojson
+++ b/data/101/850/157/101850157.geojson
@@ -87,6 +87,10 @@
         "wk:page":"Kinousa"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9670f4d5a9bc73847ca7752bfe0d9957",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709972,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03c5\u03bd\u03bf\u03cd\u03c3\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/850/159/101850159.geojson
+++ b/data/101/850/159/101850159.geojson
@@ -94,6 +94,10 @@
         "wk:page":"Makounta"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bff4d4a9a71ef73137df7b173186a39a",
     "wof:hierarchy":[
         {
@@ -107,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709972,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039c\u03b1\u03ba\u03bf\u03cd\u03bd\u03c4\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/850/161/101850161.geojson
+++ b/data/101/850/161/101850161.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Nea Dimmata"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d539fb110d79b21a4dcaa3b2adc3e08f",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101850161,
-    "wof:lastmodified":1566709972,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039d\u03ad\u03b1 \u0394\u03ae\u03bc\u03b1\u03c4\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/850/163/101850163.geojson
+++ b/data/101/850/163/101850163.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Sarama, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"864e18ea655a81838d3f885cfbcf5ddf",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709975,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u03a3\u03b1\u03c1\u03b1\u03bc\u03ac",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/850/167/101850167.geojson
+++ b/data/101/850/167/101850167.geojson
@@ -81,6 +81,9 @@
         "wk:page":"Fasli"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eac250eb05d11776d46fa80e31a07d2e",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":101850167,
-    "wof:lastmodified":1566709973,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u03a6\u03ac\u03c3\u03bb\u03b9",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/850/169/101850169.geojson
+++ b/data/101/850/169/101850169.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":9
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3eaf8845e8b5b77b8534af74203334ca",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":101850169,
-    "wof:lastmodified":1566709973,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039b\u03b9\u03b2\u03ac\u03b4\u03b9",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/850/171/101850171.geojson
+++ b/data/101/850/171/101850171.geojson
@@ -110,6 +110,10 @@
         "wk:page":"Avdellero"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2ee76f8f20073f506f0cbffadadb8f1d",
     "wof:hierarchy":[
         {
@@ -123,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709977,
+    "wof:lastmodified":1582314066,
     "wof:name":"\u0391\u03b2\u03b4\u03b5\u03bb\u03bb\u03b5\u03c1\u03cc",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/850/173/101850173.geojson
+++ b/data/101/850/173/101850173.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":9
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"906d26788819c0360f9d184f6224fddf",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101850173,
-    "wof:lastmodified":1566709974,
+    "wof:lastmodified":1582314065,
     "wof:name":"\u039a\u03cc\u03c7\u03b7",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/873/945/101873945.geojson
+++ b/data/101/873/945/101873945.geojson
@@ -86,6 +86,10 @@
         "wk:page":"Kampi"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f94321de248b32d4a484c5baad05d3d7",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709963,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039a\u03b1\u03bc\u03c0\u03af",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/873/947/101873947.geojson
+++ b/data/101/873/947/101873947.geojson
@@ -103,6 +103,10 @@
         "wk:page":"Meneou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"44ec43a093c3f9ea5e76b707e6752284",
     "wof:hierarchy":[
         {
@@ -116,7 +120,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709963,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039c\u03b5\u03bd\u03b5\u03bf\u03cd",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/875/091/101875091.geojson
+++ b/data/101/875/091/101875091.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Monarga"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63ac62d6692aa3c2b73f3235d1542788",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566709965,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039c\u03bf\u03bd\u03b1\u03c1\u03b3\u03ac",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/875/107/101875107.geojson
+++ b/data/101/875/107/101875107.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Lazanias"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de50e62370e96ea9d64622504756f3e7",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709968,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039b\u03b1\u03b6\u03b1\u03bd\u03b9\u03ac\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/875/109/101875109.geojson
+++ b/data/101/875/109/101875109.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Fikardou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8f162c2f7b94598a2eabf23f1cda41db",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709968,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u03a6\u03b9\u03ba\u03ac\u03c1\u03b4\u03bf\u03c5",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/875/115/101875115.geojson
+++ b/data/101/875/115/101875115.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Askas"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f73853aba197d88b299f0820d04722b9",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709971,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u0391\u03c3\u03ba\u03ac\u03c2",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/875/121/101875121.geojson
+++ b/data/101/875/121/101875121.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Lagoudera"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f162d0ca4b8e2cedeb90650fd49b79e8",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709968,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039b\u03b1\u03b3\u03bf\u03c5\u03b4\u03b5\u03c1\u03ac",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/875/123/101875123.geojson
+++ b/data/101/875/123/101875123.geojson
@@ -78,6 +78,9 @@
         "wk:page":"Saranti"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b24817b48369aaff5823243e09ece4ba",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709971,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u03a3\u03b1\u03c1\u03ac\u03bd\u03c4\u03b9",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/875/127/101875127.geojson
+++ b/data/101/875/127/101875127.geojson
@@ -81,6 +81,9 @@
         "wk:page":"Alithinou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c3c81efda1cc00887af72cd5ccc5dd54",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709967,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u0391\u03bb\u03b7\u03b8\u03b9\u03bd\u03bf\u03cd",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/875/129/101875129.geojson
+++ b/data/101/875/129/101875129.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Platanistasa"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1e3b2805d8bb091ee306b10e504cbcca",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709967,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u03a0\u03bb\u03b1\u03c4\u03b1\u03bd\u03b9\u03c3\u03c4\u03ac\u03c3\u03b1",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/875/159/101875159.geojson
+++ b/data/101/875/159/101875159.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Axylou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7c7321965dd1dd45c778e2160ff59446",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709964,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u0391\u03be\u03cd\u03bb\u03bf\u03c5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/161/101875161.geojson
+++ b/data/101/875/161/101875161.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Eledio"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4a55b6243bb52b001163eb845caca795",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709964,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u0395\u03bb\u03b5\u03b4\u03b9\u03cc",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/163/101875163.geojson
+++ b/data/101/875/163/101875163.geojson
@@ -78,6 +78,9 @@
         "wk:page":"Lemona, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"43cdbf2553651aa0113bd17b319639ed",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709968,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039b\u03b5\u03bc\u03ce\u03bd\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/169/101875169.geojson
+++ b/data/101/875/169/101875169.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Mamonia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7246341d9aeb8eaa5e4586e8bd6814d5",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709964,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039c\u03b1\u03bc\u03ce\u03bd\u03b9\u03b1",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/173/101875173.geojson
+++ b/data/101/875/173/101875173.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Kedares"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ad4445c12857ce2798ed10ad7389502",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709967,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039a\u03ad\u03b4\u03b1\u03c1\u03b5\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/187/101875187.geojson
+++ b/data/101/875/187/101875187.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Mamountali"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e4a31dee12ac76e44690665c1b8f21e8",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709967,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039c\u03b1\u03bc\u03bf\u03cd\u03bd\u03c4\u03b1\u03bb\u03b7",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/189/101875189.geojson
+++ b/data/101/875/189/101875189.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Asprogia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"351f1fa9d3f603c70020bc4c40efdf4b",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709967,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u0391\u03c3\u03c0\u03c1\u03bf\u03b3\u03b9\u03ac",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/191/101875191.geojson
+++ b/data/101/875/191/101875191.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Psathi, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1733b3dcd487e97f5df60f275679efa",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709968,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u03a8\u03ac\u03b8\u03b9",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/193/101875193.geojson
+++ b/data/101/875/193/101875193.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Agios Dimitrianos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b904dc14ba668f5151013dd525efa524",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709964,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u0394\u03b7\u03bc\u03b7\u03c4\u03c1\u03b9\u03b1\u03bd\u03cc\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/195/101875195.geojson
+++ b/data/101/875/195/101875195.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Milia, Paphos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fe3eef7175d42342573a9ad41d842221",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709964,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039c\u03b7\u03bb\u03b9\u03ac",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/197/101875197.geojson
+++ b/data/101/875/197/101875197.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Fyti"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9a20d2bf1ed52a877ac474c12be37a85",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709969,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u03a6\u03cd\u03c4\u03b7",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/199/101875199.geojson
+++ b/data/101/875/199/101875199.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Evretou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5f72949c7cadbccc65ae3e6dc5623bd",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709969,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u0395\u03c5\u03c1\u03ad\u03c4\u03bf\u03c5",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/207/101875207.geojson
+++ b/data/101/875/207/101875207.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Miliou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"be46615b89cc6c4952b023693566d314",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709970,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039c\u03b7\u03bb\u03b9\u03bf\u03cd",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/209/101875209.geojson
+++ b/data/101/875/209/101875209.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Skoulli"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0eef0851b1f721c7dc7183c120624f93",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709970,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u03a3\u03ba\u03bf\u03cd\u03bb\u03bb\u03b7",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/213/101875213.geojson
+++ b/data/101/875/213/101875213.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Karamoullides"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e1b6a4840d47002dd2388383e9bf8503",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709970,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039a\u03b1\u03c1\u03b1\u03bc\u03bf\u03c5\u03bb\u03bb\u03ae\u03b4\u03b5\u03c2",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/215/101875215.geojson
+++ b/data/101/875/215/101875215.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Chrysochou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d7f191311bc757ab30e774502a81a73d",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709969,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u03a7\u03c1\u03c5\u03c3\u03bf\u03c7\u03bf\u03cd",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/217/101875217.geojson
+++ b/data/101/875/217/101875217.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Goudi, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aae75c35c2bc7ee2413f1fd3aff05de0",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709965,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u0393\u03bf\u03c5\u03b4\u03af",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/219/101875219.geojson
+++ b/data/101/875/219/101875219.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Gialia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb002f54b0297a13485affdd5443571f",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709965,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u0393\u03b9\u03b1\u03bb\u03b9\u03ac",
     "wof:parent_id":85682401,
     "wof:placetype":"locality",

--- a/data/101/875/237/101875237.geojson
+++ b/data/101/875/237/101875237.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q16269991"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eccd264a3ea8f17e95d450873dbc75b3",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709971,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039a\u03ac\u03c4\u03c9 \u039b\u03b5\u03cd\u03ba\u03b1\u03c1\u03b1",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/875/241/101875241.geojson
+++ b/data/101/875/241/101875241.geojson
@@ -106,6 +106,9 @@
         "wk:page":"Kato Drys"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"198eae78479b0126404a609a96062174",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709969,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039a\u03ac\u03c4\u03c9 \u0394\u03c1\u03c5\u03c2",
     "wof:parent_id":85682407,
     "wof:placetype":"locality",

--- a/data/101/875/245/101875245.geojson
+++ b/data/101/875/245/101875245.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Moni, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"00c5164e38dc8b4d77ad3135521d3004",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709965,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039c\u03bf\u03bd\u03ae",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/249/101875249.geojson
+++ b/data/101/875/249/101875249.geojson
@@ -80,6 +80,9 @@
         "wk:page":"Klonari"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"40ee1e37377fbc282ea482c3dfb27945",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709970,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039a\u03bb\u03c9\u03bd\u03ac\u03c1\u03b9",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/253/101875253.geojson
+++ b/data/101/875/253/101875253.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Akapnou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"704cc50f91fc8b2857cf1637a2995ad0",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709970,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u0391\u03ba\u03b1\u03c0\u03bd\u03bf\u03cd",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/255/101875255.geojson
+++ b/data/101/875/255/101875255.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Platanisteia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"43590d0a6a78cdead2167f3c67bae114",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709971,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u03a0\u03bb\u03b1\u03c4\u03b1\u03bd\u03af\u03c3\u03c4\u03b5\u03b9\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/259/101875259.geojson
+++ b/data/101/875/259/101875259.geojson
@@ -99,6 +99,9 @@
         "wd:id":"Q4831309"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3c00c2a2735fb1bb2003d5dd1135947c",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709966,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u0386\u03b3\u03b9\u03bf\u03c2 \u0398\u03c9\u03bc\u03ac\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/263/101875263.geojson
+++ b/data/101/875/263/101875263.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Doros, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1e023bd5284c1aa84418b8e2ceebcec9",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709971,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u0394\u03c9\u03c1\u03cc\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/265/101875265.geojson
+++ b/data/101/875/265/101875265.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Laneia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f6a9dea498f65544d001b85eaea9ddc2",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709971,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039b\u03ac\u03bd\u03b5\u03b9\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/267/101875267.geojson
+++ b/data/101/875/267/101875267.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Monagri"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef691cfc980bba428cda240f7b3f7128",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709966,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039c\u03bf\u03bd\u03ac\u03b3\u03c1\u03b9",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/269/101875269.geojson
+++ b/data/101/875/269/101875269.geojson
@@ -77,6 +77,9 @@
         "wk:page":"Kouka, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a50d617fad85336ab02407175c363822",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709966,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039a\u03bf\u03c5\u03ba\u03ac",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/271/101875271.geojson
+++ b/data/101/875/271/101875271.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Kissousa"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"504c162ae3ff136dd38dc0a255d4997f",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709970,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u039a\u03b9\u03c3\u03c3\u03bf\u03cd\u03c3\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/273/101875273.geojson
+++ b/data/101/875/273/101875273.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Malia, Cyprus"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"57da164589f73e312de81b27941a4fa7",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709965,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u039c\u03b1\u03bb\u03b9\u03ac",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/279/101875279.geojson
+++ b/data/101/875/279/101875279.geojson
@@ -81,6 +81,9 @@
         "wk:page":"Potamiou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3788929497d55db5e90d92751a53eaf3",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709969,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u03a0\u03bf\u03c4\u03b1\u03bc\u03b9\u03bf\u03cd",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/281/101875281.geojson
+++ b/data/101/875/281/101875281.geojson
@@ -78,6 +78,9 @@
         "wk:page":"Potamitissa"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbe0e08757ea4ad40591d193027a912f",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709965,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u03a0\u03bf\u03c4\u03b1\u03bc\u03af\u03c4\u03b9\u03c3\u03c3\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/283/101875283.geojson
+++ b/data/101/875/283/101875283.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Dymes"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d58c868e980a6812bf84ecd4ac324dcb",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709969,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u0394\u03cd\u03bc\u03b5\u03c2",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/285/101875285.geojson
+++ b/data/101/875/285/101875285.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Agridia"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92e799f3ec5e05fe1a7a4c9c5690bf93",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709970,
+    "wof:lastmodified":1582314064,
     "wof:name":"\u0391\u03b3\u03c1\u03af\u03b4\u03b9\u03b1",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/875/287/101875287.geojson
+++ b/data/101/875/287/101875287.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Chandria"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"970e96b982997ec206c632cf4ec7d1d1",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709965,
+    "wof:lastmodified":1582314063,
     "wof:name":"\u03a7\u03b1\u03bd\u03b4\u03c1\u03b9\u03ac",
     "wof:parent_id":85682411,
     "wof:placetype":"locality",

--- a/data/101/876/315/101876315.geojson
+++ b/data/101/876/315/101876315.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Linou"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8b844cddbd4864c64697b4cff56da5b",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566710006,
+    "wof:lastmodified":1582314071,
     "wof:name":"\u039b\u03b7\u03bd\u03bf\u03cd",
     "wof:parent_id":85682397,
     "wof:placetype":"locality",

--- a/data/101/911/237/101911237.geojson
+++ b/data/101/911/237/101911237.geojson
@@ -80,6 +80,9 @@
         "wk:page":"Paramali"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"733854b9d0841a6ef33472fecf3da086",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101911237,
-    "wof:lastmodified":1566710014,
+    "wof:lastmodified":1582314074,
     "wof:name":"Paramali",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/101/911/713/101911713.geojson
+++ b/data/101/911/713/101911713.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Achna"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e3aa74e8006043c2794e44f0f0b351e4",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":101911713,
-    "wof:lastmodified":1566710014,
+    "wof:lastmodified":1582314074,
     "wof:name":"Athna",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/856/324/37/85632437.geojson
+++ b/data/856/324/37/85632437.geojson
@@ -1030,6 +1030,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1084,6 +1085,10 @@
     },
     "wof:country":"CY",
     "wof:country_alpha3":"CYP",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"513b91f22a5a88b80103b4a6d5637dd9",
     "wof:hierarchy":[
         {
@@ -1100,7 +1105,7 @@
         "ell",
         "tur"
     ],
-    "wof:lastmodified":1566709958,
+    "wof:lastmodified":1582314062,
     "wof:name":"Cyprus",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/324/37/85632437.geojson
+++ b/data/856/324/37/85632437.geojson
@@ -1030,7 +1030,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1105,7 +1104,7 @@
         "ell",
         "tur"
     ],
-    "wof:lastmodified":1582314062,
+    "wof:lastmodified":1583200758,
     "wof:name":"Cyprus",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/859/014/53/85901453.geojson
+++ b/data/859/014/53/85901453.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":278076
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"017de4b45ea5221e1dcea6dbff6f1e7f",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709958,
+    "wof:lastmodified":1582314062,
     "wof:name":"Ktima",
     "wof:parent_id":101749143,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/55/85901455.geojson
+++ b/data/859/014/55/85901455.geojson
@@ -370,6 +370,10 @@
         "wk:page":"Paphos"
     },
     "wof:country":"CY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"96382ec51fb70a65237287ad3da538ef",
     "wof:hierarchy":[
         {
@@ -384,7 +388,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566709958,
+    "wof:lastmodified":1582314062,
     "wof:name":"Nea Paphos",
     "wof:parent_id":101749143,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.