### PR TITLE
Name updates

### DIFF
--- a/data/856/324/37/85632437.geojson
+++ b/data/856/324/37/85632437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.530982,
-    "geom:area_square_m":5383780568.215252,
+    "geom:area_square_m":5383779716.697944,
     "geom:bbox":"32.267887,34.632303,34.091221,35.194557",
     "geom:latitude":34.916415,
     "geom:longitude":32.988458,
@@ -43,6 +43,9 @@
     "name:aka_x_preferred":[
         "Saepr\u0254s"
     ],
+    "name:aka_x_variant":[
+        "Cyprus"
+    ],
     "name:als_x_preferred":[
         "Republik Zypern"
     ],
@@ -63,6 +66,9 @@
     ],
     "name:arg_x_preferred":[
         "Chipre"
+    ],
+    "name:ary_x_preferred":[
+        "\u0642\u0628\u0631\u0635"
     ],
     "name:arz_x_preferred":[
         "\u0642\u0628\u0631\u0635"
@@ -90,6 +96,9 @@
     ],
     "name:bam_x_preferred":[
         "Cipri"
+    ],
+    "name:ban_x_preferred":[
+        "Siprus"
     ],
     "name:bar_x_preferred":[
         "Republik Zypern"
@@ -196,6 +205,12 @@
     "name:dan_x_preferred":[
         "Cypern"
     ],
+    "name:deu_at_x_preferred":[
+        "Republik Zypern"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Republik Zypern"
+    ],
     "name:deu_x_preferred":[
         "Republik Zypern"
     ],
@@ -222,6 +237,12 @@
         "Kipriak\u00ed Dhimokrat\u00eda",
         "K\u00fdpros",
         "\u039a\u03c5\u03c0\u03c1\u03b9\u03b1\u03ba\u03ae \u0394\u03b7\u03bc\u03bf\u03ba\u03c1\u03b1\u03c4\u03af\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Cyprus"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Cyprus"
     ],
     "name:eng_x_preferred":[
         "Cyprus"
@@ -306,6 +327,9 @@
     "name:gag_x_preferred":[
         "Kipra Respublikas\u0131"
     ],
+    "name:gcr_x_preferred":[
+        "Chip"
+    ],
     "name:gla_x_preferred":[
         "C\u00ecopras"
     ],
@@ -323,6 +347,9 @@
     ],
     "name:gom_x_preferred":[
         "\u0938\u093e\u092f\u092a\u094d\u0930\u0938"
+    ],
+    "name:got_x_preferred":[
+        "\ud800\udf3a\ud800\udf3f\ud800\udf40\ud800\udf42\ud800\udf45\ud800\udf43"
     ],
     "name:grn_x_preferred":[
         "Chipre"
@@ -545,6 +572,9 @@
     "name:mhr_x_preferred":[
         "\u041a\u0438\u043f\u0440"
     ],
+    "name:min_x_preferred":[
+        "Siprus"
+    ],
     "name:mkd_x_preferred":[
         "\u041a\u0438\u043f\u0430\u0440"
     ],
@@ -663,6 +693,9 @@
     "name:pap_x_preferred":[
         "Chipre"
     ],
+    "name:pcd_x_preferred":[
+        "Kipre"
+    ],
     "name:pih_x_preferred":[
         "Siipris"
     ],
@@ -680,6 +713,9 @@
     ],
     "name:pol_x_preferred":[
         "Cypr"
+    ],
+    "name:por_br_x_preferred":[
+        "Chipre"
     ],
     "name:por_x_preferred":[
         "Chipre"
@@ -759,6 +795,9 @@
     "name:sna_x_preferred":[
         "Cyprus"
     ],
+    "name:snd_x_preferred":[
+        "\u0642\u0628\u0631\u0635"
+    ],
     "name:som_x_preferred":[
         "Jasiirada Qabrus"
     ],
@@ -783,6 +822,12 @@
     "name:srn_x_preferred":[
         "Sipruskondre"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u041a\u0438\u043f\u0430\u0440"
+    ],
+    "name:srp_el_x_preferred":[
+        "Kipar"
+    ],
     "name:srp_x_preferred":[
         "\u041a\u0438\u043f\u0430\u0440"
     ],
@@ -806,6 +851,9 @@
     ],
     "name:szl_x_preferred":[
         "Cypr"
+    ],
+    "name:szy_x_preferred":[
+        "Cyprus"
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc8\u0baa\u0bcd\u0baa\u0bbf\u0bb0\u0b9a\u0bc1"
@@ -907,6 +955,9 @@
     "name:war_x_preferred":[
         "Tsipre"
     ],
+    "name:wln_x_preferred":[
+        "Ch\u00eepe"
+    ],
     "name:wol_x_preferred":[
         "Ciip\u00ebr"
     ],
@@ -940,8 +991,26 @@
     "name:zha_x_preferred":[
         "Cyprus"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u585e\u6d66\u8def\u65af"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u585e\u6d66\u8def\u65af"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Ku-p\u00ed-l\u014d\u0358"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u585e\u6d66\u8def\u65af"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u585e\u6d66\u8def\u65af"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u585e\u6d66\u8def\u65af"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u8cfd\u666e\u52d2\u65af"
     ],
     "name:zho_x_preferred":[
         "\u8cfd\u666e\u52d2\u65af"
@@ -1105,7 +1174,7 @@
         "ell",
         "tur"
     ],
-    "wof:lastmodified":1583797320,
+    "wof:lastmodified":1587428726,
     "wof:name":"Cyprus",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.