### PR TITLE
cy concordances, placetype local, and more

### DIFF
--- a/data/856/324/37/85632437.geojson
+++ b/data/856/324/37/85632437.geojson
@@ -1290,6 +1290,7 @@
         "hasc:id":"CY",
         "icao:code":"5B",
         "ioc:id":"CYP",
+        "iso:code":"CY",
         "itu:id":"CYP",
         "loc:id":"n79055857",
         "m49:code":"196",
@@ -1303,6 +1304,7 @@
         "wk:page":"Cyprus",
         "wmo:id":"CY"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CY",
     "wof:country_alpha3":"CYP",
     "wof:geom_alt":[
@@ -1325,7 +1327,7 @@
         "ell",
         "tur"
     ],
-    "wof:lastmodified":1694492264,
+    "wof:lastmodified":1695881376,
     "wof:name":"Cyprus",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/823/89/85682389.geojson
+++ b/data/856/823/89/85682389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.196673,
-    "geom:area_square_m":1985109643.658165,
+    "geom:area_square_m":1985109570.487113,
     "geom:bbox":"33.540729,34.955112,34.588642,35.696094",
     "geom:latitude":35.285682,
     "geom:longitude":33.914648,
@@ -278,12 +278,18 @@
         "gn:id":-1,
         "gp:id":12577963,
         "hasc:id":"CY.FA",
+        "iso:code":"CY-04",
         "iso:id":"CY-04",
+        "qs:local_id":"3",
         "unlc:id":"CY-04",
         "wd:id":"Q59148"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CY",
-    "wof:geomhash":"7d3043060539d7d8fc8effed82b99edf",
+    "wof:geomhash":"889e1a3aa99afd1e63235b7951e1bfef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -307,7 +313,7 @@
         "ell",
         "tur"
     ],
-    "wof:lastmodified":1690869064,
+    "wof:lastmodified":1695884503,
     "wof:name":"\u0391\u03bc\u03bc\u03cc\u03c7\u03c9\u03c3\u03c4\u03bf\u03c2",
     "wof:parent_id":85632375,
     "wof:placetype":"region",

--- a/data/856/823/93/85682393.geojson
+++ b/data/856/823/93/85682393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063812,
-    "geom:area_square_m":643922599.948197,
+    "geom:area_square_m":643922447.887214,
     "geom:bbox":"32.919444,35.233631,33.671512,35.403824",
     "geom:latitude":35.30623,
     "geom:longitude":33.237075,
@@ -248,12 +248,18 @@
         "fips:code":"CY02",
         "gp:id":12577969,
         "hasc:id":"CY.KY",
+        "iso:code":"CY-06",
         "iso:id":"CY-06",
+        "qs:local_id":"2",
         "unlc:id":"CY-06",
         "wd:id":"Q59146"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CY",
-    "wof:geomhash":"f75772e1538eab029aaedeba31f0f3c7",
+    "wof:geomhash":"7b775cdeefbf0ca393c9934fabfa126d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -277,7 +283,7 @@
         "ell",
         "tur"
     ],
-    "wof:lastmodified":1690869063,
+    "wof:lastmodified":1695884503,
     "wof:name":"\u039a\u03b5\u03c1\u03cd\u03bd\u03b5\u03b9\u03b1",
     "wof:parent_id":85632375,
     "wof:placetype":"region",

--- a/data/856/823/97/85682397.geojson
+++ b/data/856/823/97/85682397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.267865,
-    "geom:area_square_m":2710348481.319896,
+    "geom:area_square_m":2710348700.367243,
     "geom:bbox":"32.567726,34.887409,33.593452,35.284916",
     "geom:latitude":35.085671,
     "geom:longitude":33.109901,
@@ -297,12 +297,18 @@
         "gn:id":146267,
         "gp:id":12577971,
         "hasc:id":"CY.NI",
+        "iso:code":"CY-01",
         "iso:id":"CY-01",
+        "qs:local_id":"1",
         "unlc:id":"CY-01",
         "wd:id":"Q59147"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CY",
-    "wof:geomhash":"ed0e6215293395990a0e08e765254951",
+    "wof:geomhash":"03aad2d87841f9706650dbb31bed0f94",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -319,7 +325,7 @@
         "ell",
         "tur"
     ],
-    "wof:lastmodified":1690869064,
+    "wof:lastmodified":1695884504,
     "wof:name":"\u039b\u03b5\u03c5\u03ba\u03c9\u03c3\u03af\u03b1",
     "wof:parent_id":85632437,
     "wof:placetype":"region",

--- a/data/856/824/01/85682401.geojson
+++ b/data/856/824/01/85682401.geojson
@@ -289,10 +289,16 @@
         "gn:id":146213,
         "gp:id":12577966,
         "hasc:id":"CY.PA",
+        "iso:code":"CY-05",
         "iso:id":"CY-05",
+        "qs:local_id":"6",
         "unlc:id":"CY-05",
         "wd:id":"Q59133"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CY",
     "wof:geomhash":"bb2423eed48a6f84cd2d4a4579b8a2b1",
     "wof:hierarchy":[
@@ -311,7 +317,7 @@
         "ell",
         "tur"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884504,
     "wof:name":"Paphos",
     "wof:parent_id":85632437,
     "wof:placetype":"region",

--- a/data/856/824/07/85682407.geojson
+++ b/data/856/824/07/85682407.geojson
@@ -307,10 +307,16 @@
         "gn:id":146398,
         "gp:id":12577964,
         "hasc:id":"CY.LA",
+        "iso:code":"CY-03",
         "iso:id":"CY-03",
+        "qs:local_id":"4",
         "unlc:id":"CY-03",
         "wd:id":"Q59153"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CY",
     "wof:geomhash":"226b8ac36abea1d37b0b2858cc3639d2",
     "wof:hierarchy":[
@@ -329,7 +335,7 @@
         "ell",
         "tur"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884504,
     "wof:name":"Larnaca",
     "wof:parent_id":85632437,
     "wof:placetype":"region",

--- a/data/856/824/11/85682411.geojson
+++ b/data/856/824/11/85682411.geojson
@@ -153,9 +153,15 @@
         "gn:id":146383,
         "gp:id":12577965,
         "hasc:id":"CY.LI",
+        "iso:code":"CY-02",
         "iso:id":"CY-02",
+        "qs:local_id":"5",
         "unlc:id":"CY-02"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CY",
     "wof:geomhash":"8a980aba0f553fca742163d96bad3eaf",
     "wof:hierarchy":[
@@ -174,7 +180,7 @@
         "ell",
         "tur"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884504,
     "wof:name":"Limassol",
     "wof:parent_id":85632437,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.